### PR TITLE
refactor: reuse `iq` abstraction in `rtlsdr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "rtl-sdr-rs"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484b7bec2ca1b0f6fdf0ea856b7ee02b401af30651562d0f0b59d05e6e9ea33d"
+checksum = "c5d26b3e8cd61d6b0bf5fb1683ffc50dea910b097754c9623be021188d4ebc6d"
 dependencies = [
  "byteorder",
  "log",

--- a/crates/rs162/Cargo.toml
+++ b/crates/rs162/Cargo.toml
@@ -15,7 +15,7 @@ deku = "0.19.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-complex = "0.4"
-rtl-sdr-rs = "0.1.0"
+rtl-sdr-rs = "0.2"
 futures = "0.3.31"
 tokio = { version = "1.48.0", features = ["full"] }
 once_cell = "1.21.3"

--- a/crates/rs162/examples/rtlsdr.rs
+++ b/crates/rs162/examples/rtlsdr.rs
@@ -1,19 +1,28 @@
 use rs162::{decode::mmsi::MmsiInfo, sources::rtlsdr::RtlSdrReceiver};
+use rtl_sdr_rs::error::Result;
 use serde_json::json;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<()> {
     let receiver = RtlSdrReceiver::new()?;
 
-    for msg in receiver {
-        if let Some(ais_msg) = msg.decode() {
-            let output = json!({
-                "signal_level": msg.signal_level,
-                "timestamp": msg.timestamp,
-                "channel": msg.channel,
-                "message": ais_msg,
-                "mmsi_info": MmsiInfo::from_message(&ais_msg).ok()
-            });
-            println!("{}", serde_json::to_string(&output).unwrap());
+    for msg_res in receiver {
+        match msg_res {
+            Ok(msg) => {
+                if let Some(ais_msg) = msg.decode() {
+                    let output = json!({
+                        "signal_level": msg.signal_level,
+                        "timestamp": msg.timestamp,
+                        "channel": msg.channel,
+                        "message": ais_msg,
+                        "mmsi_info": MmsiInfo::from_message(&ais_msg).ok()
+                    });
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                }
+            }
+            Err(e) => {
+                eprintln!("I/O error reading samples: {e}");
+                continue;
+            }
         }
     }
 

--- a/crates/rs162/examples/rtlsdr_async.rs
+++ b/crates/rs162/examples/rtlsdr_async.rs
@@ -1,20 +1,29 @@
 use futures::StreamExt; // for .next().await
 use rs162::sources::rtlsdr::AsyncRtlSdrReceiver;
+use rtl_sdr_rs::error::Result;
 use serde_json::json;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<()> {
     let mut receiver = AsyncRtlSdrReceiver::new().await?;
 
-    while let Some(msg) = receiver.next().await {
-        if let Some(ais_msg) = msg.decode() {
-            let output = json!({
-                "signal_level": msg.signal_level,
-                "timestamp": msg.timestamp,
-                "channel": msg.channel,
-                "message": ais_msg
-            });
-            println!("{}", serde_json::to_string(&output)?);
+    while let Some(msg_res) = receiver.next().await {
+        match msg_res {
+            Ok(msg) => {
+                if let Some(ais_msg) = msg.decode() {
+                    let output = json!({
+                        "signal_level": msg.signal_level,
+                        "timestamp": msg.timestamp,
+                        "channel": msg.channel,
+                        "message": ais_msg
+                    });
+                    println!("{}", serde_json::to_string(&output).unwrap());
+                }
+            }
+            Err(e) => {
+                eprintln!("I/O error reading samples: {e}");
+                continue;
+            }
         }
     }
     println!("Stream returned None, exiting loop"); // Debug log

--- a/crates/rs162/src/decode/ais/type1.rs
+++ b/crates/rs162/src/decode/ais/type1.rs
@@ -226,7 +226,7 @@ mod tests {
 
         // Test that we can serialize and deserialize
         let json = msg.to_json().unwrap();
-        let expected_json = r#"{"msg_type":1,"repeat":0,"mmsi":366053209,"status":"RestrictedManoeuverability","turn":0.0,"speed":0.0,"accuracy":false,"longitude":-122.34161833333333,"latitude":37.80211833333333,"course":219.3,"heading":1,"second":59,"maneuver":"NotAvailable","raim":false,"radio":2281}"#;
+        let expected_json = r#"{"msg_type":1,"repeat":0,"mmsi":366053209,"status":"RestrictedManoeuverability","turn":0.0,"speed":0.0,"accuracy":false,"longitude":-122.34161833333333,"latitude":37.80211833333333,"course":219.3,"heading":1,"second":59,"maneuver":"N/A","raim":false,"radio":2281}"#;
         assert_eq!(json, expected_json);
     }
 

--- a/crates/rs162/src/sources/iq.rs
+++ b/crates/rs162/src/sources/iq.rs
@@ -1,11 +1,19 @@
 //! Generic I/Q source for reading complex samples from any `Read` source.
+//!
+//! Formats with 16/32-bit samples are little-endian (Cs16, Cf32).
 
+use futures::Stream;
 use num_complex::Complex;
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{BufReader, Read};
+use std::marker::PhantomData;
 use std::net::TcpStream;
 use std::path::Path;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::sync::mpsc;
 
 use crate::dsp::ais::{AisDemodulatedMessage, AisDemodulator};
 
@@ -17,68 +25,85 @@ pub enum IqFormat {
     Cf32, // Complex 32-bit float
 }
 
+const DEFAULT_CHUNK_SAMPLES: usize = 8192;
+
+impl IqFormat {
+    fn bytes_per_sample(self) -> usize {
+        match self {
+            IqFormat::Cu8 | IqFormat::Cs8 => 2,
+            IqFormat::Cs16 => 4,
+            IqFormat::Cf32 => 8,
+        }
+    }
+}
+
+fn convert_bytes_to_complex(format: IqFormat, buffer: &[u8]) -> Vec<Complex<f32>> {
+    match format {
+        IqFormat::Cu8 => buffer
+            .chunks_exact(2)
+            .map(|c| Complex::new((c[0] as f32 - 127.5) / 128.0, (c[1] as f32 - 127.5) / 128.0))
+            .collect(),
+        IqFormat::Cs8 => buffer
+            .chunks_exact(2)
+            .map(|c| Complex::new((c[0] as i8) as f32 / 128.0, (c[1] as i8) as f32 / 128.0))
+            .collect(),
+        IqFormat::Cs16 => buffer
+            .chunks_exact(4)
+            .map(|c| {
+                Complex::new(
+                    i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0,
+                    i16::from_le_bytes([c[2], c[3]]) as f32 / 32768.0,
+                )
+            })
+            .collect(),
+        IqFormat::Cf32 => buffer
+            .chunks_exact(8)
+            .map(|c| {
+                Complex::new(
+                    f32::from_le_bytes([c[0], c[1], c[2], c[3]]),
+                    f32::from_le_bytes([c[4], c[5], c[6], c[7]]),
+                )
+            })
+            .collect(),
+    }
+}
+
 pub struct IqSource<R: Read> {
-    reader: BufReader<R>,
+    reader: R,
     format: IqFormat,
     demodulator: AisDemodulator,
     chunk_size: usize,
     message_buffer: VecDeque<AisDemodulatedMessage>,
+    terminated: bool,
 }
 
 impl<R: Read> IqSource<R> {
     pub fn new(reader: R, sample_rate: u32, format: IqFormat) -> Self {
-        let reader = BufReader::new(reader);
         let demodulator = AisDemodulator::new(sample_rate);
         Self {
             reader,
             format,
             demodulator,
-            chunk_size: 8192,
+            chunk_size: DEFAULT_CHUNK_SAMPLES,
             message_buffer: VecDeque::new(),
+            terminated: false,
         }
     }
 
     fn read_samples(&mut self) -> Result<Vec<Complex<f32>>, std::io::Error> {
-        let bytes_per_sample = match self.format {
-            IqFormat::Cu8 | IqFormat::Cs8 => 2,
-            IqFormat::Cs16 => 4,
-            IqFormat::Cf32 => 8,
-        };
+        let bytes_per_sample = self.format.bytes_per_sample();
         let mut buffer = vec![0u8; self.chunk_size * bytes_per_sample];
+        // TODO: partial trailing data at EOF is dropped (same for async!)
+        // use rollover buffer.
         self.reader.read_exact(&mut buffer)?;
-
-        let samples = match self.format {
-            IqFormat::Cu8 => buffer
-                .chunks_exact(2)
-                .map(|c| Complex::new((c[0] as f32 - 127.5) / 128.0, (c[1] as f32 - 127.5) / 128.0))
-                .collect(),
-            IqFormat::Cs8 => buffer
-                .chunks_exact(2)
-                .map(|c| Complex::new((c[0] as i8) as f32 / 128.0, (c[1] as i8) as f32 / 128.0))
-                .collect(),
-            IqFormat::Cs16 => buffer
-                .chunks_exact(4)
-                .map(|c| {
-                    Complex::new(
-                        i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0,
-                        i16::from_le_bytes([c[2], c[3]]) as f32 / 32768.0,
-                    )
-                })
-                .collect(),
-            IqFormat::Cf32 => buffer
-                .chunks_exact(8)
-                .map(|c| {
-                    Complex::new(
-                        f32::from_le_bytes([c[0], c[1], c[2], c[3]]),
-                        f32::from_le_bytes([c[4], c[5], c[6], c[7]]),
-                    )
-                })
-                .collect(),
-        };
+        let samples = convert_bytes_to_complex(self.format, &buffer);
         Ok(samples)
     }
 
     fn next_message(&mut self) -> Option<Result<AisDemodulatedMessage, std::io::Error>> {
+        if self.terminated {
+            return None;
+        }
         if let Some(msg) = self.message_buffer.pop_front() {
             return Some(Ok(msg));
         }
@@ -87,6 +112,7 @@ impl<R: Read> IqSource<R> {
             match self.read_samples() {
                 Ok(samples) => {
                     if samples.is_empty() {
+                        self.terminated = true;
                         return None; // EOF
                     }
                     let messages = self.demodulator.demodulate(&samples);
@@ -97,8 +123,10 @@ impl<R: Read> IqSource<R> {
                 }
                 Err(e) => {
                     if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                        self.terminated = true;
                         return None;
                     }
+                    self.terminated = true;
                     return Some(Err(e));
                 }
             }
@@ -106,25 +134,27 @@ impl<R: Read> IqSource<R> {
     }
 }
 
-impl IqSource<File> {
+impl IqSource<BufReader<File>> {
     pub fn from_file<P: AsRef<Path>>(
         path: P,
         sample_rate: u32,
         format: IqFormat,
     ) -> Result<Self, std::io::Error> {
         let file = File::open(path)?;
-        Ok(Self::new(file, sample_rate, format))
+        let reader = BufReader::new(file);
+        Ok(Self::new(reader, sample_rate, format))
     }
 }
 
-impl IqSource<TcpStream> {
+impl IqSource<BufReader<TcpStream>> {
     pub fn from_tcp(
         addr: &str,
         sample_rate: u32,
         format: IqFormat,
     ) -> Result<Self, std::io::Error> {
         let stream = TcpStream::connect(addr)?;
-        Ok(Self::new(stream, sample_rate, format))
+        let reader = BufReader::new(stream);
+        Ok(Self::new(reader, sample_rate, format))
     }
 }
 
@@ -133,5 +163,56 @@ impl<R: Read> Iterator for IqSource<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_message()
+    }
+}
+
+pub struct AsyncIqSource<R: AsyncRead + Unpin + Send + 'static> {
+    rx: mpsc::Receiver<Result<AisDemodulatedMessage, std::io::Error>>,
+    _task: tokio::task::JoinHandle<()>,
+    _phantom: PhantomData<R>,
+}
+
+impl<R: AsyncRead + Unpin + Send + 'static> AsyncIqSource<R> {
+    pub fn new(reader: R, sample_rate: u32, format: IqFormat) -> Self {
+        let (tx, rx) = mpsc::channel::<Result<AisDemodulatedMessage, std::io::Error>>(32);
+        let mut reader = reader;
+        let handle = tokio::spawn(async move {
+            let mut demodulator = AisDemodulator::new(sample_rate);
+            let chunk_size = DEFAULT_CHUNK_SAMPLES;
+            let bytes_per_sample = format.bytes_per_sample();
+            let mut buffer = vec![0u8; chunk_size * bytes_per_sample];
+            loop {
+                match reader.read_exact(&mut buffer).await {
+                    Ok(_) => {
+                        let samples: Vec<Complex<f32>> = convert_bytes_to_complex(format, &buffer);
+                        let messages = demodulator.demodulate(&samples);
+                        for msg in messages {
+                            if tx.send(Ok(msg)).await.is_err() {
+                                return;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        if e.kind() != std::io::ErrorKind::UnexpectedEof {
+                            let _ = tx.send(Err(e)).await;
+                        }
+                        return;
+                    }
+                }
+            }
+        });
+        Self {
+            rx,
+            _task: handle,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<R: AsyncRead + Unpin + Send + 'static> Stream for AsyncIqSource<R> {
+    type Item = Result<AisDemodulatedMessage, std::io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.rx.poll_recv(cx)
     }
 }

--- a/crates/rs162/src/sources/rtlsdr.rs
+++ b/crates/rs162/src/sources/rtlsdr.rs
@@ -2,18 +2,15 @@
 //!
 //! This module provides real-time AIS signal demodulation from RTL-SDR dongles.
 
-use crate::dsp::ais::{AisDemodulatedMessage, AisDemodulator, AIS_SAMPLE_RATE_288K};
-use crate::dsp::convert_samples_cu8;
+use crate::dsp::ais::{AisDemodulatedMessage, AIS_SAMPLE_RATE_288K};
+use crate::sources::iq::{AsyncIqSource, IqFormat, IqSource};
 use futures::Stream;
-use num_complex::Complex;
+use rtl_sdr_rs::error::RtlsdrError;
 use rtl_sdr_rs::{RtlSdr, TunerGain, DEFAULT_BUF_LENGTH};
-use std::collections::VecDeque;
+use std::io::{self, Read};
 use std::pin::Pin;
-use std::sync::mpsc as mpsc_sync;
 use std::task::{Context, Poll};
-use std::thread;
-use tokio::sync::mpsc as mpsc_tokio;
-use tracing::error;
+use tokio::io::{AsyncRead, ReadBuf};
 
 /// Configuration for RTL-SDR AIS reception
 #[derive(Debug, Clone)]
@@ -22,7 +19,7 @@ pub struct RtlSdrConfig {
     pub device_index: usize,
     /// Center frequency in Hz (e.g., 162_000_000 for AIS)
     pub frequency: u32,
-    /// Sample rate in Hz (must be 96000 for current demodulator)
+    /// Sample rate in Hz (must be 288000 = AIS_SAMPLE_RATE_288K for current demodulator)
     pub sample_rate: u32,
     /// Tuner gain (None for AGC, Some(gain) for manual)
     pub gain: Option<i32>,
@@ -47,223 +44,249 @@ impl RtlSdrConfig {
     }
 }
 
+struct RtlSdrReader {
+    rtl: RtlSdr,
+    buf: Vec<u8>,
+    pos: usize,
+    end: usize,
+}
+
+impl RtlSdrReader {
+    fn new(config: &RtlSdrConfig) -> Result<Self, RtlsdrError> {
+        let mut rtl = RtlSdr::open_with_index(config.device_index)?;
+        rtl.set_sample_rate(config.sample_rate)?;
+        rtl.set_center_freq(config.frequency)?;
+        match config.gain {
+            Some(gain) => rtl.set_tuner_gain(TunerGain::Manual(gain))?,
+            None => rtl.set_tuner_gain(TunerGain::Auto)?,
+        };
+        let _ = rtl.set_bias_tee(false);
+        rtl.reset_buffer()?;
+        Ok(Self {
+            rtl,
+            buf: vec![0u8; DEFAULT_BUF_LENGTH],
+            pos: 0,
+            end: 0,
+        })
+    }
+}
+
+impl Read for RtlSdrReader {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        // NOTE: we do not use BufReader here to ensure device reads happen in large chunks.
+        if self.pos == self.end {
+            match self.rtl.read_sync(&mut self.buf[..]) {
+                Ok(n) => {
+                    self.pos = 0;
+                    self.end = n;
+                    if n == 0 {
+                        return Ok(0);
+                    }
+                }
+                Err(err) => {
+                    // NOTE: `RtlsdrError: Into<Box<(dyn StdError + std::marker::Send + Sync + 'static)>>` is not satisfied
+                    return Err(io::Error::new(io::ErrorKind::Other, err.to_string()));
+                }
+            }
+        }
+
+        let available = self.end - self.pos;
+        let to_copy = available.min(dst.len());
+        dst[..to_copy].copy_from_slice(&self.buf[self.pos..self.pos + to_copy]);
+        self.pos += to_copy;
+        Ok(to_copy)
+    }
+}
+
 /// RTL-SDR AIS receiver
 /// Example usage
 ///
 /// ```no_run
-/// use rs162::sources::rtlsdr::{RtlSdrReceiver, RtlSdrConfig};
+/// use rs162::sources::rtlsdr::RtlSdrReceiver;
 ///
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let mut receiver = RtlSdrReceiver::new()?;
 ///
-///     receiver.receive(|message| {
-///         println!("AIS Message on channel {}: {} bytes",
-///                  message.channel, message.bits.len());
-///     })?;
-///     for msg in receiver {
-///         if let Some(ais_msg) = msg.decode() {
-///             let output = json!({
-///                 "signal_level": msg.signal_level,
-///                 "timestamp": msg.timestamp,
-///                 "channel": msg.channel,
-///                 "message": ais_msg,
-///                 "mmsi_info": MmsiInfo::from_message(&ais_msg).ok()
-///             });
-///             println!("{}", serde_json::to_string(&output).unwrap());
+///     for item in receiver {
+///         match item {
+///             Ok(msg) => {
+///                 println!("AIS Message on channel {}: {} bits", msg.channel, msg.bits.len());
+///             }
+///             Err(e) => {
+///                 eprintln!("Receiver error: {e}");
+///             }
 ///         }
 ///     }
+///
 ///     Ok(())
 /// }
 /// ```
 pub struct RtlSdrReceiver {
-    demodulator: AisDemodulator,
-    sample_receiver: mpsc_sync::Receiver<Vec<Complex<f32>>>,
-    message_buffer: VecDeque<AisDemodulatedMessage>,
-    _handle: thread::JoinHandle<()>, // Keep handle to prevent thread from being dropped
+    inner: IqSource<RtlSdrReader>,
 }
 
 impl RtlSdrReceiver {
     /// Create a new RTL-SDR receiver with default configuration
-    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new() -> Result<Self, RtlsdrError> {
         Self::with_config(RtlSdrConfig::default())
     }
 
     /// Create a new RTL-SDR receiver with custom configuration
-    pub fn with_config(config: RtlSdrConfig) -> Result<Self, Box<dyn std::error::Error>> {
-        let demodulator = AisDemodulator::new(config.sample_rate);
-        let (tx, rx) = mpsc_sync::channel();
-
-        // Spawn RTL-SDR reading thread
-        let handle = thread::spawn(move || {
-            let mut rtl = RtlSdr::open(config.device_index).expect("No such device");
-
-            rtl.set_sample_rate(config.sample_rate)
-                .expect("Failed to set sample rate");
-            rtl.set_center_freq(config.frequency)
-                .expect("Failed to set frequency");
-            match config.gain {
-                Some(gain) => rtl
-                    .set_tuner_gain(TunerGain::Manual(gain))
-                    .expect("Failed to set gain"),
-                None => rtl
-                    .set_tuner_gain(TunerGain::Auto)
-                    .expect("Failed to set automatic gain"),
-            };
-
-            // Reset bias tee (if supported)
-            let _ = rtl.set_bias_tee(false);
-
-            // Create sample buffer
-            let mut buffer = Box::new([0u8; DEFAULT_BUF_LENGTH]);
-
-            rtl.reset_buffer().expect("Unable to reset buffer");
-
-            loop {
-                if let Ok(bytes_read) = rtl.read_sync(&mut *buffer) {
-                    // Convert samples and update stats
-                    let samples = convert_samples_cu8(&buffer[..bytes_read]);
-
-                    if tx.send(samples).is_err() {
-                        return; // Stop reading if receiver is dropped
-                    }
-                }
-            }
-        });
-
-        Ok(Self {
-            demodulator,
-            sample_receiver: rx,
-            message_buffer: VecDeque::new(),
-            _handle: handle,
-        })
-    }
-
-    /// Get the next AIS message
-    fn next_message(&mut self) -> Option<AisDemodulatedMessage> {
-        // Return buffered message if available
-        if let Some(msg) = self.message_buffer.pop_front() {
-            return Some(msg);
-        }
-
-        // Process incoming samples
-        loop {
-            match self.sample_receiver.try_recv() {
-                Ok(samples) => {
-                    let messages = self.demodulator.demodulate(&samples);
-
-                    // Add all messages to buffer
-                    for msg in messages {
-                        self.message_buffer.push_back(msg);
-                    }
-
-                    // Return first message if any
-                    if let Some(msg) = self.message_buffer.pop_front() {
-                        return Some(msg);
-                    }
-                    // Continue processing if no messages were found
-                }
-                Err(mpsc_sync::TryRecvError::Empty) => {
-                    // No new samples available yet, try again
-                    std::thread::sleep(std::time::Duration::from_millis(1));
-                    continue;
-                }
-                Err(mpsc_sync::TryRecvError::Disconnected) => {
-                    // RTL-SDR thread has stopped
-                    return None;
-                }
-            }
-        }
+    pub fn with_config(config: RtlSdrConfig) -> Result<Self, RtlsdrError> {
+        let reader = RtlSdrReader::new(&config)?;
+        let inner = IqSource::new(reader, config.sample_rate, IqFormat::Cu8);
+        Ok(Self { inner })
     }
 }
 
 impl Iterator for RtlSdrReceiver {
-    type Item = AisDemodulatedMessage;
+    type Item = Result<AisDemodulatedMessage, io::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next_message()
+        self.inner.next()
     }
 }
 
-pub struct AsyncRtlSdrReceiver {
-    demodulator: AisDemodulator,
-    sample_receiver: mpsc_tokio::Receiver<Vec<Complex<f32>>>,
-    message_buffer: VecDeque<AisDemodulatedMessage>,
-    _handle: std::thread::JoinHandle<()>, // Keep handle to prevent thread from being dropped
+/// Async reader over an internal blocking thread and mpsc channel.
+/// Maintains an eof flag to avoid repeated polls after end-of-stream.
+struct AsyncRtlSdrReader {
+    rx: tokio::sync::mpsc::Receiver<Result<Vec<u8>, io::Error>>,
+    buf: Vec<u8>,
+    pos: usize,
+    eof: bool,
+    _handle: std::thread::JoinHandle<()>,
 }
 
-impl AsyncRtlSdrReceiver {
-    pub async fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        Self::with_config(RtlSdrConfig::default()).await
-    }
+impl AsyncRtlSdrReader {
+    fn new(config: &RtlSdrConfig) -> Result<Self, RtlsdrError> {
+        let (tx_data, rx) = tokio::sync::mpsc::channel::<Result<Vec<u8>, io::Error>>(32);
+        let (tx_init, rx_init) = std::sync::mpsc::channel::<Result<(), RtlsdrError>>();
+        let cfg = config.clone();
 
-    pub async fn with_config(config: RtlSdrConfig) -> Result<Self, Box<dyn std::error::Error>> {
-        let demodulator = AisDemodulator::new(config.sample_rate);
-        let (tx, rx) = mpsc_tokio::channel::<Vec<Complex<f32>>>(32);
-
-        // Spawn blocking SDR reading thread
         let handle = std::thread::spawn(move || {
-            let mut rtl = RtlSdr::open(config.device_index).expect("No such device");
-            rtl.set_sample_rate(config.sample_rate)
-                .expect("Failed to set sample rate");
-            rtl.set_center_freq(config.frequency)
-                .expect("Failed to set frequency");
-            match config.gain {
-                Some(gain) => rtl
-                    .set_tuner_gain(TunerGain::Manual(gain))
-                    .expect("Failed to set gain"),
-                None => rtl
-                    .set_tuner_gain(TunerGain::Auto)
-                    .expect("Failed to set automatic gain"),
-            };
+            let init_res = (|| -> Result<RtlSdr, RtlsdrError> {
+                let mut rtl = RtlSdr::open_with_index(cfg.device_index)?;
+                rtl.set_sample_rate(cfg.sample_rate)?;
+                rtl.set_center_freq(cfg.frequency)?;
+                match cfg.gain {
+                    Some(gain) => rtl.set_tuner_gain(TunerGain::Manual(gain))?,
+                    None => rtl.set_tuner_gain(TunerGain::Auto)?,
+                };
+                let _ = rtl.set_bias_tee(false);
+                rtl.reset_buffer()?;
+                Ok(rtl)
+            })();
 
-            let mut buffer = Box::new([0u8; DEFAULT_BUF_LENGTH]);
-            rtl.reset_buffer().expect("Unable to reset buffer");
-
-            loop {
-                match rtl.read_sync(&mut *buffer) {
-                    Ok(bytes_read) => {
-                        let samples = convert_samples_cu8(&buffer[..bytes_read]);
-                        if tx.blocking_send(samples).is_err() {
-                            println!("Async RTL-SDR receiver channel closed");
-                            return; // Stop reading if receiver is dropped
+            match init_res {
+                Ok(rtl) => {
+                    let _ = tx_init.send(Ok(()));
+                    let mut buffer = vec![0u8; DEFAULT_BUF_LENGTH];
+                    loop {
+                        match rtl.read_sync(&mut buffer) {
+                            Ok(bytes_read) => {
+                                if bytes_read == 0 {
+                                    let _ = tx_data.blocking_send(Ok(Vec::new()));
+                                    return;
+                                }
+                                let chunk = buffer[..bytes_read].to_vec();
+                                if tx_data.blocking_send(Ok(chunk)).is_err() {
+                                    return;
+                                }
+                            }
+                            Err(e) => {
+                                let _ = tx_data.blocking_send(Err(io::Error::new(
+                                    io::ErrorKind::Other,
+                                    e.to_string(),
+                                )));
+                                return;
+                            }
                         }
                     }
-                    Err(err) => {
-                        error!("Error reading from RTL-SDR device: {:?}", err);
-                    }
+                }
+                Err(e) => {
+                    let _ = tx_init.send(Err(e));
                 }
             }
         });
 
-        Ok(Self {
-            demodulator,
-            sample_receiver: rx,
-            message_buffer: VecDeque::new(),
-            _handle: handle,
-        })
+        match rx_init.recv() {
+            Ok(Ok(())) => Ok(Self {
+                rx,
+                buf: Vec::new(),
+                pos: 0,
+                eof: false,
+                _handle: handle,
+            }),
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(RtlsdrError::RtlsdrErr(
+                "Async RTL-SDR init failed".to_string(),
+            )),
+        }
+    }
+}
+
+impl AsyncRead for AsyncRtlSdrReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        dst: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.eof {
+            return Poll::Ready(Ok(()));
+        }
+
+        if self.pos < self.buf.len() {
+            let remaining = self.buf.len() - self.pos;
+            let to_copy = remaining.min(dst.remaining());
+            dst.put_slice(&self.buf[self.pos..self.pos + to_copy]);
+            self.pos += to_copy;
+            return Poll::Ready(Ok(()));
+        }
+
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                if chunk.is_empty() {
+                    self.eof = true; // by device
+                    return Poll::Ready(Ok(()));
+                }
+                self.buf = chunk;
+                self.pos = 0;
+                let to_copy = self.buf.len().min(dst.remaining());
+                dst.put_slice(&self.buf[..to_copy]);
+                self.pos = to_copy;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Err(e)),
+            Poll::Ready(None) => {
+                self.eof = true; // channel closed
+                Poll::Ready(Ok(()))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pub struct AsyncRtlSdrReceiver {
+    inner: AsyncIqSource<AsyncRtlSdrReader>,
+}
+
+impl AsyncRtlSdrReceiver {
+    pub async fn new() -> Result<Self, RtlsdrError> {
+        Self::with_config(RtlSdrConfig::default()).await
+    }
+
+    pub async fn with_config(config: RtlSdrConfig) -> Result<Self, RtlsdrError> {
+        let reader = AsyncRtlSdrReader::new(&config)?;
+        let inner = AsyncIqSource::new(reader, config.sample_rate, IqFormat::Cu8);
+        Ok(Self { inner })
     }
 }
 
 impl Stream for AsyncRtlSdrReceiver {
-    type Item = AisDemodulatedMessage;
+    type Item = Result<AisDemodulatedMessage, io::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(msg) = self.message_buffer.pop_front() {
-            return Poll::Ready(Some(msg));
-        }
-
-        match self.sample_receiver.poll_recv(cx) {
-            Poll::Ready(Some(samples)) => {
-                let messages = self.demodulator.demodulate(&samples);
-                self.message_buffer.extend(messages);
-                match self.message_buffer.pop_front() {
-                    Some(msg) => Poll::Ready(Some(msg)),
-                    None => Poll::Pending,
-                }
-            }
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
+        Pin::new(&mut self.inner).poll_next(cx)
     }
 }
 


### PR DESCRIPTION
following https://github.com/xoolive/ship162/pull/2#issuecomment-3476393116
- the public-facing `RtlSdrReceiver` and `AsyncRtlSdrReceiver` are now thin wrappers around `IqSource` and `AsyncIqSource`.
- improved error handling by propagating I/O errors through the `Iterator` and `Stream` as `Result` items
- bumped `rtl-sdr-rs` to 0.2.0 to support R828D tuner
- test: fix false positive in `test_message_serialisation`

Can confirm it works with rtl-sdr blog v4 (r828d) with this patch applied: https://github.com/ccostes/rtl-sdr-rs/pull/24

```sh
cargo run --release --example rtlsdr
cargo run --release --example rtlsdr_async
```