### PR TITLE
Fix cargo dist for musl and Windows platforms

### DIFF
--- a/crates/rs162/Cargo.toml
+++ b/crates/rs162/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 [features]
 mqtt = ["dep:paho-mqtt"]
 airspy = ['desperado/airspy']
-rtlsdr = ['desperado/rtlsdr']
+rtlsdr = ['desperado/rtlsdr', 'dep:rtl-sdr-rs']
 soapy = ['desperado/soapy']
 ssh = ['async-recursion', 'dirs', 'makiko', 'ssh2-config']
 
@@ -22,7 +22,7 @@ deku = "0.20.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 num-complex = "0.4"
-rtl-sdr-rs = "0.3"
+rtl-sdr-rs = { version = "0.3", optional = true }
 futures = "0.3.32"
 tokio = { version = "1", features = ["full"] }
 once_cell = "1.21.3"

--- a/crates/ship162/build.rs
+++ b/crates/ship162/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // Set stack size to 8 MB on Windows MSVC to avoid stack overflows
+    // during deep recursive parsing
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if target.contains("msvc") {
+        println!("cargo:rustc-link-arg=/stack:8388608");
+    }
+}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,14 @@ installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
 tap = "xoolive/homebrew-homebrew"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-unknown-linux-musl",
+    "x86_64-pc-windows-msvc",
+]
 # Which actions to run on pull requests
 pr-run-mode = "upload"
 # Path that installers should place binaries in
@@ -22,13 +29,20 @@ publish-jobs = ["homebrew"]
 # Whether to install an updater program
 install-updater = true
 # Features to pass to cargo build
-features = ["mqtt", "rtlsdr", "ssh"]
+# Note: rtlsdr and soapy are excluded because they require system
+# libraries (libusb) that are not available on all platforms.
+# Users with SDR hardware should build from source with --features rtlsdr.
+features = ["ssh"]
 
 [dist.dependencies.apt]
-libusb-dev = "*"
+libssl-dev = "*"
+pkg-config = "*"
 
 [dist.dependencies.homebrew]
-libusb = { stage = ["build", "run"] }
+openssl = { stage = ["build", "run"] }
+
+[dist.dependencies.chocolatey]
+openssl = "*"
 
 [dist.github-custom-runners]
 global = "ubuntu-latest"


### PR DESCRIPTION
## Summary

Addresses #9 and supersedes #8.

- **Make `rtl-sdr-rs` optional** in rs162 — it was a non-optional dependency pulling in `libusb1-sys` but never directly imported (only `desperado/rtlsdr` uses the hardware). This was the root cause of the musl build failure.
- **Add musl and Windows targets**: `x86_64-unknown-linux-musl`, `x86_64-pc-windows-msvc`
- **Drop `rtlsdr` and `mqtt` from dist features** — they require system C libraries (`libusb`, `paho-mqtt`) unavailable on musl/Windows. Users with SDR hardware build from source.
- **Keep `ssh` feature** in dist (works everywhere via openssl)
- **Add `build.rs`** with MSVC 8MB stack size (from jet1090)
- **Add system deps** for openssl (`apt`, `homebrew`, `chocolatey`)

## Changes

| File | Change |
|------|--------|
| `crates/rs162/Cargo.toml` | `rtl-sdr-rs` → optional, gated behind `rtlsdr` feature |
| `dist-workspace.toml` | Add musl + Windows targets, update features and deps |
| `crates/ship162/build.rs` | MSVC stack size (from jet1090) |

## Test plan

- [x] `cargo check --features ssh` — builds without libusb
- [x] `cargo check --features ssh,rtlsdr` — rtlsdr still works when enabled
- [x] `cargo clippy --features ssh` — zero warnings
- [x] Verified `libusb1-sys` is completely absent from dep tree without `rtlsdr` feature
- [ ] CI will test musl and Windows builds on this PR (`pr-run-mode = "upload"`)