### PR TITLE
fix(ship162): isolate tui and json output from diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,6 +3228,7 @@ dependencies = [
  "rs162",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "toml",

--- a/config.toml.example
+++ b/config.toml.example
@@ -105,6 +105,7 @@ bias_tee = false   # Enable to power external LNA (default: false)
 # Example 13: TCP source (Norwegian AIS server)
 [[sources]]
 tcp = "153.44.253.27:5631"
+retry = { strategy = "fixed", delay_seconds = 5 }
 
 # Example 14: TCP source with SSH tunnel (requires ssh feature)
 # [[sources]]
@@ -120,6 +121,7 @@ tcp = "153.44.253.27:5631"
 # Example 15: WebSocket source
 # [[sources]]
 # ws = "ws://remote_host:88888"
+# retry = { strategy = "fixed", delay_seconds = 5 }
 
 # Example 16: WebSocket source with SSH tunnel (requires ssh feature)
 # [[sources]]

--- a/config.toml.example
+++ b/config.toml.example
@@ -10,7 +10,7 @@
 # output = "/tmp/ais_messages.jsonl"
 
 # Logging configuration
-# log_file = "/tmp/ship162.log"  # Use "-" for stdout (only in non-interactive mode)
+# log_file = "/tmp/ship162.log"  # Use "-" for stdout only without verbose or interactive mode
 
 # Prevent computer from sleeping while decoding
 prevent_sleep = false

--- a/crates/rs162/src/sources/ssh.rs
+++ b/crates/rs162/src/sources/ssh.rs
@@ -314,7 +314,7 @@ impl TunnelledTcp {
         let target_client = connect_server(&self.jump, &params, CONNECTION_MAP.clone())
             .await
             .map_err(|e| {
-                let msg = format!("Could not connect to jump host {}: {}", &self.jump, e);
+                let msg = format!("Could not connect to jump host {}: {}", self.jump, e);
                 BoxError::from(msg)
             })?;
 
@@ -339,7 +339,7 @@ impl TunnelledWebsocket {
         let target_client = connect_server(&self.jump, &params, CONNECTION_MAP.clone())
             .await
             .map_err(|e| {
-                let msg = format!("Could not connect to jump host {}: {}", &self.jump, e);
+                let msg = format!("Could not connect to jump host {}: {}", self.jump, e);
                 BoxError::from(msg)
             })?;
 

--- a/crates/ship162/Cargo.toml
+++ b/crates/ship162/Cargo.toml
@@ -43,3 +43,4 @@ toml = "0.9.10"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = "2.5.7"
 tokio-tungstenite = "0.29"
+thiserror = "2"  # available in rs162

--- a/crates/ship162/src/main.rs
+++ b/crates/ship162/src/main.rs
@@ -3,6 +3,7 @@
 mod outputs;
 mod sources;
 mod state;
+mod status;
 mod table;
 mod tui;
 
@@ -26,7 +27,7 @@ use std::{path::PathBuf, sync::Arc};
 use tokio::{
     fs,
     io::AsyncWriteExt,
-    sync::{watch, Mutex},
+    sync::{mpsc, watch, Mutex},
 };
 use tracing::{error, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
@@ -36,6 +37,7 @@ use crate::sources::iq::Source;
 use crate::sources::mqtt::MqttSource;
 use crate::sources::tcp::TcpSource;
 use crate::sources::websocket::WsSource;
+use crate::status::{ReconnectingSource, SourceEvent, SourceId, SourceRuntime};
 use crate::tui::{Event, EventHandler};
 use rs162::sources::AisAsyncIqSource;
 
@@ -204,7 +206,10 @@ async fn main() -> Result<()> {
                 .with(fmt::layer().with_writer(file).with_ansi(false))
                 .init();
         }
-        None if options.interactive => subscriber.init(),
+        None if options.interactive => {
+            // TODO: surface non-network source and output errors inside the TUI
+            subscriber.init();
+        }
         None => subscriber
             .with(fmt::layer().with_writer(std::io::stderr))
             .init(),
@@ -249,6 +254,14 @@ async fn main() -> Result<()> {
 
     // Create application state wrapped in Arc<Mutex<>> for sharing
     let state = Arc::new(Mutex::new(AppState::new()));
+    let (status_tx, mut status_rx) = mpsc::unbounded_channel::<SourceEvent>();
+    let status_state = state.clone();
+    let status_handle = tokio::spawn(async move {
+        while let Some(status) = status_rx.recv().await {
+            status.log();
+            status_state.lock().await.set_source_status(status);
+        }
+    });
 
     let (tx, mut rx) = tokio::sync::mpsc::channel(10);
     let (quit_tx, mut quit_rx) = watch::channel(false);
@@ -346,72 +359,63 @@ async fn main() -> Result<()> {
         options.serve_tcp.is_some() || options.serve_udp.is_some() || options.serve_ws.is_some();
 
     let mut src_handles = vec![];
-    for source in options.sources {
+    for (source_index, source) in options.sources.into_iter().enumerate() {
+        let source_id = SourceId::from_index(source_index);
         let tcp_clone = tx.clone();
+        let source_status_tx = status_tx.clone();
         let mut shutdown_rx = shutdown_tx.subscribe();
-        let handle = match source.address {
-            sources::Address::Tcp(address) => tokio::spawn(async move {
-                match address {
-                    sources::AddressPath::Short(addr) => {
-                        let parts: Vec<&str> = addr.split(':').collect();
-                        if parts.len() != 2 {
-                            error!("Invalid TCP address format: {}", addr);
-                            return;
-                        }
-                        let host = parts[0].to_string();
-                        let port = parts[1].parse::<u16>().unwrap_or_else(|_| {
-                            error!("Invalid port number in address: {}", addr);
-                            0
-                        });
-                        if port == 0 {
-                            return;
-                        }
-                        let source = TcpSource::new(tcp_clone, host, port);
-                        tokio::select! {
-                            result = source.run() => {
-                                if let Err(e) = result {
-                                    error!("TCP source error: {}", e);
-                                }
-                            }
-                            _ = shutdown_rx.recv() => {
-                                // Silent shutdown
-                            }
-                        }
+        let handle = match source {
+            sources::Source::Tcp(source_config) => tokio::spawn(async move {
+                let (host, port, jump) = match source_config.tcp {
+                    sources::AddressPath::Short(address) => {
+                        (address.host, address.port.get(), None)
                     }
-                    sources::AddressPath::Long(addr) => {
-                        let host = addr.host;
-                        let port = addr.port;
-                        #[cfg(feature = "ssh")]
-                        let source = if let Some(jump) = addr.jump {
-                            TcpSource::with_jump(tcp_clone, host, port, jump)
-                        } else {
-                            TcpSource::new(tcp_clone, host, port)
-                        };
-                        #[cfg(not(feature = "ssh"))]
-                        let source = TcpSource::new(tcp_clone, host, port);
+                    sources::AddressPath::Long(address) => {
+                        (address.host, address.port.get(), address.jump)
+                    }
+                };
+                let runtime = SourceRuntime::new(
+                    source_id,
+                    format!("tcp://{host}:{port}"),
+                    source_status_tx.clone(),
+                    source_config.retry,
+                );
+                #[cfg(feature = "ssh")]
+                let source = if let Some(jump) = jump {
+                    TcpSource::with_jump(tcp_clone, runtime, host, port, jump)
+                } else {
+                    TcpSource::new(tcp_clone, runtime, host, port)
+                };
+                #[cfg(not(feature = "ssh"))]
+                let source = {
+                    let _ = jump;
+                    TcpSource::new(tcp_clone, runtime, host, port)
+                };
 
-                        tokio::select! {
-                            result = source.run() => {
-                                if let Err(e) = result {
-                                    error!("TCP source error: {}", e);
-                                }
-                            }
-                            _ = shutdown_rx.recv() => {
-                                // Silent shutdown
-                            }
-                        }
+                tokio::select! {
+                    _ = source.run() => {}
+                    _ = shutdown_rx.recv() => {
+                        // Silent shutdown
                     }
                 }
             }),
             #[cfg(feature = "mqtt")]
-            sources::Address::Mqtt(broker_url) => {
+            sources::Source::Mqtt(source_config) => {
                 let mqtt_clone = tx.clone();
                 tokio::spawn(async move {
-                    let source = MqttSource::new(mqtt_clone, broker_url);
+                    let client_id = source_config.mqtt;
+                    // TODO: split the legacy MQTT value into broker and client ID, then
+                    // expose paho connection callbacks before reporting lifecycle events in the TUI.
+                    let source = MqttSource::new(mqtt_clone, client_id.clone());
                     tokio::select! {
                         result = source.run() => {
-                            if let Err(e) = result {
-                                error!("MQTT source error: {}", e);
+                            if let Err(error) = result {
+                                error!(
+                                    source_type = "mqtt",
+                                    client_id,
+                                    error = %error,
+                                    "MQTT source error"
+                                );
                             }
                         }
                         _ = shutdown_rx.recv() => {
@@ -421,15 +425,16 @@ async fn main() -> Result<()> {
                 })
             }
             #[cfg(feature = "rtlsdr")]
-            sources::Address::Rtlsdr(rtl_path) => {
+            sources::Source::RtlSdr(source_config) => {
                 use desperado::rtlsdr::DeviceSelector;
                 let rtl_clone = tx.clone();
+                let rtl_path = source_config.rtlsdr;
 
                 // Get gain and bias_tee from source config or use defaults
-                let gain = source
+                let gain = source_config
                     .gain
                     .unwrap_or(Gain::Manual(sources::AIS_RTLSDR_GAIN));
-                let bias_tee = source.bias_tee.unwrap_or(false);
+                let bias_tee = source_config.bias_tee.unwrap_or(false);
 
                 // Determine device selector based on config
                 let config = &rtl_path.config;
@@ -452,7 +457,7 @@ async fn main() -> Result<()> {
                 };
 
                 // Get sample rate from source config or use default 288 kHz
-                let sample_rate = source
+                let sample_rate = source_config
                     .sample_rate
                     .map(|r| r as u32)
                     .unwrap_or(AIS_SAMPLE_RATE_288K);
@@ -473,17 +478,18 @@ async fn main() -> Result<()> {
                 })
             }
             #[cfg(feature = "soapy")]
-            sources::Address::Soapy(soapy_path) => {
+            sources::Source::Soapy(source_config) => {
                 let soapy_clone = tx.clone();
+                let soapy_path = source_config.soapy;
                 let args = soapy_path.soapy.clone();
 
                 // Get configuration from source or use defaults
-                let gain = source
+                let gain = source_config
                     .gain
                     .unwrap_or(Gain::Manual(sources::AIS_RTLSDR_GAIN));
-                let bias_tee = source.bias_tee.unwrap_or(false);
+                let bias_tee = source_config.bias_tee.unwrap_or(false);
                 // Use specified sample rate or default to 288 kHz
-                let sample_rate = source
+                let sample_rate = source_config
                     .sample_rate
                     .map(|r| r as u32)
                     .unwrap_or(AIS_SAMPLE_RATE_288K);
@@ -505,10 +511,11 @@ async fn main() -> Result<()> {
                 })
             }
             #[cfg(feature = "airspy")]
-            sources::Address::Airspy(airspy_path) => {
+            sources::Source::Airspy(source_config) => {
                 use desperado::airspy::DeviceSelector as AirspyDeviceSelector;
 
                 let airspy_clone = tx.clone();
+                let airspy_path = source_config.airspy;
 
                 let config = &airspy_path.config;
                 let device = if let Some(idx) = config.device {
@@ -526,9 +533,12 @@ async fn main() -> Result<()> {
                 };
 
                 // Default: sensitivity gain 50 (0-100 percentage for Airspy sensitivity table)
-                let gain = source.gain.clone().unwrap_or(Gain::Manual(50.0));
-                let bias_tee = source.bias_tee.unwrap_or(false);
-                let sample_rate = source.sample_rate.map(|r| r as u32).unwrap_or(6_000_000);
+                let gain = source_config.gain.clone().unwrap_or(Gain::Manual(50.0));
+                let bias_tee = source_config.bias_tee.unwrap_or(false);
+                let sample_rate = source_config
+                    .sample_rate
+                    .map(|r| r as u32)
+                    .unwrap_or(6_000_000);
                 let lna_gain = config.lna_gain;
                 let mixer_gain = config.mixer_gain;
                 let vga_gain = config.vga_gain;
@@ -558,8 +568,9 @@ async fn main() -> Result<()> {
                 })
             }
             #[cfg(feature = "hackrf")]
-            sources::Address::Hackrf(hackrf_path) => {
+            sources::Source::HackRf(source_config) => {
                 let hackrf_clone = tx.clone();
+                let hackrf_path = source_config.hackrf;
 
                 let config = &hackrf_path.config;
                 let device_index = config.device.unwrap_or(0);
@@ -586,7 +597,7 @@ async fn main() -> Result<()> {
                         });
                     }
                     Gain::Elements(elements)
-                } else if let Some(g) = source.gain.clone() {
+                } else if let Some(g) = source_config.gain.clone() {
                     g
                 } else {
                     Gain::Elements(vec![
@@ -600,8 +611,8 @@ async fn main() -> Result<()> {
                         },
                     ])
                 };
-                let bias_tee = source.bias_tee.unwrap_or(false);
-                let sample_rate = source
+                let bias_tee = source_config.bias_tee.unwrap_or(false);
+                let sample_rate = source_config
                     .sample_rate
                     .map(|r| r as u32)
                     .unwrap_or(AIS_SAMPLE_RATE_288K);
@@ -628,8 +639,9 @@ async fn main() -> Result<()> {
                     }
                 })
             }
-            sources::Address::IqFile(file) => {
+            sources::Source::IqFile(source_config) => {
                 let file_clone = tx.clone();
+                let file = source_config.iqfile;
                 let source = AisAsyncIqSource::from_file(
                     &file,
                     AIS_SAMPLE_RATE_288K,
@@ -650,16 +662,27 @@ async fn main() -> Result<()> {
                     }
                 })
             }
-            sources::Address::Ws(ws_path) => {
+            sources::Source::WebSocket(source_config) => {
                 let ws_clone = tx.clone();
                 tokio::spawn(async move {
-                    let source = WsSource::new(ws_clone, ws_path);
+                    let ws_path = source_config.ws;
+                    let retry_policy = source_config.retry;
+                    let source_name = match &ws_path {
+                        sources::WsPath::Short(url) => url.as_str(),
+                        sources::WsPath::Long(ws) => ws.url.as_str(),
+                    };
+                    let source = WsSource::new(
+                        ws_clone,
+                        SourceRuntime::new(
+                            source_id,
+                            source_name,
+                            source_status_tx.clone(),
+                            retry_policy,
+                        ),
+                        ws_path,
+                    );
                     tokio::select! {
-                        result = source.run() => {
-                            if let Err(e) = result {
-                                error!("WebSocket source error: {}", e);
-                            }
-                        }
+                        _ = source.run() => {}
                         _ = shutdown_rx.recv() => {
                             // Silent shutdown
                         }
@@ -829,6 +852,9 @@ async fn main() -> Result<()> {
     for handle in src_handles {
         let _ = tokio::time::timeout(timeout, handle).await;
     }
+
+    drop(status_tx);
+    let _ = tokio::time::timeout(timeout, status_handle).await;
 
     Ok(())
 }

--- a/crates/ship162/src/main.rs
+++ b/crates/ship162/src/main.rs
@@ -6,7 +6,7 @@ mod state;
 mod table;
 mod tui;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use crossterm::event::{KeyCode, KeyModifiers};
 #[cfg(any(
@@ -28,7 +28,7 @@ use tokio::{
     io::AsyncWriteExt,
     sync::{watch, Mutex},
 };
-use tracing::warn;
+use tracing::{error, warn};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use crate::sources::iq::Source;
@@ -63,7 +63,7 @@ struct Options {
     #[serde(default)]
     sources: Vec<sources::Source>,
 
-    /// logging file, use "-" for stdout (only in non-interactive mode)
+    /// Diagnostic log file. "-" writes to stdout and cannot be combined with interactive or verbose output.
     #[arg(short, long, value_name = "FILE")]
     log_file: Option<String>,
 
@@ -118,16 +118,20 @@ async fn main() -> Result<()> {
     cfg_path.push("config.toml");
 
     if cfg_path.exists() {
-        let string = fs::read_to_string(cfg_path).await.ok().unwrap();
-        options = toml::from_str(&string).unwrap();
+        let string = fs::read_to_string(&cfg_path)
+            .await
+            .with_context(|| format!("failed to read config {}", cfg_path.display()))?;
+        options = toml::from_str(&string)
+            .with_context(|| format!("invalid config {}", cfg_path.display()))?;
     }
 
     if let Ok(config_file) = std::env::var("SHIP162_CONFIG") {
         let path = expanduser(PathBuf::from(config_file));
-        let string = fs::read_to_string(path)
+        let string = fs::read_to_string(&path)
             .await
-            .expect("Configuration file not found");
-        options = toml::from_str(&string).unwrap();
+            .with_context(|| format!("failed to read config {}", path.display()))?;
+        options = toml::from_str(&string)
+            .with_context(|| format!("invalid config {}", path.display()))?;
     }
 
     let mut cli_options = Options::parse();
@@ -169,24 +173,41 @@ async fn main() -> Result<()> {
     }
     options.sources.append(&mut cli_options.sources);
 
+    if options.interactive && options.verbose {
+        anyhow::bail!(
+            "interactive mode cannot be combined with verbose JSON output because both use stdout"
+        );
+    }
+    if options.log_file.as_deref() == Some("-") {
+        if options.interactive {
+            anyhow::bail!(
+                r#"log_file = "-" cannot be used in interactive mode because stdout is reserved for the TUI"#
+            );
+        }
+        if options.verbose {
+            anyhow::bail!(
+                r#"log_file = "-" cannot be used with verbose JSON output because stdout is reserved for JSON"#
+            );
+        }
+    }
+
     // example: RUST_LOG=rs162=DEBUG
-    let env_filter = EnvFilter::from_default_env();
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn"));
 
     let subscriber = tracing_subscriber::registry().with(env_filter);
     match options.log_file.as_deref() {
-        Some("-") if !options.interactive => {
-            // when it's interactive, logs will disrupt the display
-            subscriber.with(fmt::layer().pretty()).init();
-        }
-        Some(log_file) if log_file != "-" => {
+        Some("-") => subscriber.with(fmt::layer().pretty()).init(),
+        Some(log_file) => {
             let file = std::fs::File::create(log_file)
-                .unwrap_or_else(|_| panic!("fail to create log file: {log_file}"));
-            let file_layer = fmt::layer().with_writer(file).with_ansi(false);
-            subscriber.with(file_layer).init();
+                .with_context(|| format!("failed to create log file {log_file}"))?;
+            subscriber
+                .with(fmt::layer().with_writer(file).with_ansi(false))
+                .init();
         }
-        _ => {
-            subscriber.init(); // no logging
-        }
+        None if options.interactive => subscriber.init(),
+        None => subscriber
+            .with(fmt::layer().with_writer(std::io::stderr))
+            .init(),
     }
 
     let mut redis_connect = match options
@@ -281,7 +302,7 @@ async fn main() -> Result<()> {
         let tx = nmea_tx.clone();
         tokio::spawn(async move {
             if let Err(e) = outputs::tcp::run_tcp_server(addr, shutdown, tx).await {
-                eprintln!("TCP output server error: {}", e);
+                error!("TCP output server error: {}", e);
             }
         });
     }
@@ -305,7 +326,7 @@ async fn main() -> Result<()> {
         let targets = udp_targets;
         tokio::spawn(async move {
             if let Err(e) = outputs::udp::run_udp_server(addr, targets, shutdown, rx).await {
-                eprintln!("UDP output server error: {}", e);
+                error!("UDP output server error: {}", e);
             }
         });
     }
@@ -316,7 +337,7 @@ async fn main() -> Result<()> {
         let tx = nmea_tx.clone();
         tokio::spawn(async move {
             if let Err(e) = outputs::websocket::run_websocket_server(addr, shutdown, tx).await {
-                eprintln!("WebSocket output server error: {}", e);
+                error!("WebSocket output server error: {}", e);
             }
         });
     }
@@ -334,12 +355,12 @@ async fn main() -> Result<()> {
                     sources::AddressPath::Short(addr) => {
                         let parts: Vec<&str> = addr.split(':').collect();
                         if parts.len() != 2 {
-                            eprintln!("Invalid TCP address format: {}", addr);
+                            error!("Invalid TCP address format: {}", addr);
                             return;
                         }
                         let host = parts[0].to_string();
                         let port = parts[1].parse::<u16>().unwrap_or_else(|_| {
-                            eprintln!("Invalid port number in address: {}", addr);
+                            error!("Invalid port number in address: {}", addr);
                             0
                         });
                         if port == 0 {
@@ -349,7 +370,7 @@ async fn main() -> Result<()> {
                         tokio::select! {
                             result = source.run() => {
                                 if let Err(e) = result {
-                                    eprintln!("TCP source error: {}", e);
+                                    error!("TCP source error: {}", e);
                                 }
                             }
                             _ = shutdown_rx.recv() => {
@@ -372,7 +393,7 @@ async fn main() -> Result<()> {
                         tokio::select! {
                             result = source.run() => {
                                 if let Err(e) = result {
-                                    eprintln!("TCP source error: {}", e);
+                                    error!("TCP source error: {}", e);
                                 }
                             }
                             _ = shutdown_rx.recv() => {
@@ -390,7 +411,7 @@ async fn main() -> Result<()> {
                     tokio::select! {
                         result = source.run() => {
                             if let Err(e) = result {
-                                eprintln!("MQTT source error: {}", e);
+                                error!("MQTT source error: {}", e);
                             }
                         }
                         _ = shutdown_rx.recv() => {
@@ -442,7 +463,7 @@ async fn main() -> Result<()> {
                     tokio::select! {
                         result = source.run() => {
                             if let Err(e) = result {
-                                eprintln!("RTL-SDR source error: {}", e);
+                                error!("RTL-SDR source error: {}", e);
                             }
                         }
                         _ = shutdown_rx.recv() => {
@@ -474,7 +495,7 @@ async fn main() -> Result<()> {
                     tokio::select! {
                         result = source.run() => {
                             if let Err(e) = result {
-                                eprintln!("SoapySDR source error: {}", e);
+                                error!("SoapySDR source error: {}", e);
                             }
                         }
                         _ = shutdown_rx.recv() => {
@@ -496,7 +517,7 @@ async fn main() -> Result<()> {
                     match sources::parse_airspy_serial(serial) {
                         Ok(value) => AirspyDeviceSelector::Serial(value),
                         Err(message) => {
-                            eprintln!("WARNING: {message}. Defaulting to Airspy device 0.");
+                            warn!("{message}. Defaulting to Airspy device 0.");
                             AirspyDeviceSelector::Index(0)
                         }
                     }
@@ -527,7 +548,7 @@ async fn main() -> Result<()> {
                     tokio::select! {
                         result = source.run() => {
                             if let Err(e) = result {
-                                eprintln!("Airspy source error: {}", e);
+                                error!("Airspy source error: {}", e);
                             }
                         }
                         _ = shutdown_rx.recv() => {
@@ -598,7 +619,7 @@ async fn main() -> Result<()> {
                     tokio::select! {
                         result = source.run() => {
                             if let Err(e) = result {
-                                eprintln!("HackRF source error: {}", e);
+                                error!("HackRF source error: {}", e);
                             }
                         }
                         _ = shutdown_rx.recv() => {
@@ -620,7 +641,7 @@ async fn main() -> Result<()> {
                     tokio::select! {
                         result = source.run() => {
                             if let Err(e) = result {
-                                eprintln!("IQ File source error: {}", e);
+                                error!("IQ File source error: {}", e);
                             }
                         }
                         _ = shutdown_rx.recv() => {
@@ -636,7 +657,7 @@ async fn main() -> Result<()> {
                     tokio::select! {
                         result = source.run() => {
                             if let Err(e) = result {
-                                eprintln!("WebSocket source error: {}", e);
+                                error!("WebSocket source error: {}", e);
                             }
                         }
                         _ = shutdown_rx.recv() => {

--- a/crates/ship162/src/sources/iq.rs
+++ b/crates/ship162/src/sources/iq.rs
@@ -33,7 +33,7 @@ impl Source {
                 }
             }
         }
-        println!("Stream returned None, exiting loop"); // Debug log
+        tracing::info!("source stream ended");
 
         Ok(())
     }

--- a/crates/ship162/src/sources/mod.rs
+++ b/crates/ship162/src/sources/mod.rs
@@ -1,4 +1,8 @@
-use std::str::FromStr;
+use std::{
+    fmt,
+    num::{NonZeroU16, ParseIntError},
+    str::FromStr,
+};
 
 #[cfg(feature = "airspy")]
 pub use desperado::sdr::parse_airspy_serial;
@@ -10,18 +14,24 @@ use desperado::sdr::{AirspyDeviceConfig, AirspyPath};
 use desperado::sdr::{HackrfDeviceConfig, HackrfPath};
 #[cfg(feature = "rtlsdr")]
 use desperado::sdr::{RtlSdrDeviceConfig, RtlSdrPath};
-#[cfg(any(feature = "rtlsdr", feature = "soapy", feature = "airspy"))]
+#[cfg(any(
+    feature = "rtlsdr",
+    feature = "soapy",
+    feature = "airspy",
+    feature = "hackrf"
+))]
 use desperado::Gain;
 use rs162::{
     decode::ais::type24,
     prelude::{Message, MmsiInfo},
 };
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tokio::sync::MutexGuard;
 use tracing::error;
 use url::Url;
 
-use crate::state::AppState;
+use crate::{state::AppState, status::RetryPolicy};
 
 pub mod iq;
 #[cfg(feature = "mqtt")]
@@ -32,18 +42,100 @@ pub mod websocket;
 // AIS-specific constants for SDR devices
 #[cfg(any(feature = "rtlsdr", feature = "soapy"))]
 pub const AIS_RTLSDR_GAIN: f64 = 49.6; // Maximum gain recommended for 162 MHz
+#[derive(Debug, Error)]
+pub enum TcpAddressError {
+    #[error("invalid TCP address `{address}`: expected host:port")]
+    TcpPortMissing { address: String },
+    #[error("invalid TCP address `{address}`: host is empty")]
+    TcpHostEmpty { address: String },
+    #[error("invalid TCP address `{address}`: IPv6 addresses must be enclosed in brackets")]
+    TcpIpv6NotBracketed { address: String },
+    #[error("invalid TCP address `{address}`: port must be between 1 and 65535")]
+    TcpPortInvalid {
+        address: String,
+        #[source]
+        source: ParseIntError,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TcpAddress {
+    pub host: String,
+    pub port: NonZeroU16,
+}
+
+impl FromStr for TcpAddress {
+    type Err = TcpAddressError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (host, port) =
+            value
+                .rsplit_once(':')
+                .ok_or_else(|| TcpAddressError::TcpPortMissing {
+                    address: value.to_string(),
+                })?;
+        if host.is_empty() {
+            return Err(TcpAddressError::TcpHostEmpty {
+                address: value.to_string(),
+            });
+        }
+        if host.contains(':') && !(host.starts_with('[') && host.ends_with(']')) {
+            return Err(TcpAddressError::TcpIpv6NotBracketed {
+                address: value.to_string(),
+            });
+        }
+        let port =
+            port.parse::<NonZeroU16>()
+                .map_err(|source| TcpAddressError::TcpPortInvalid {
+                    address: value.to_string(),
+                    source,
+                })?;
+
+        Ok(Self {
+            host: host.to_string(),
+            port,
+        })
+    }
+}
+
+impl fmt::Display for TcpAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.host, self.port)
+    }
+}
+
+impl Serialize for TcpAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for TcpAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddressStruct {
     pub host: String,
-    pub port: u16,
+    pub port: NonZeroU16,
     pub jump: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AddressPath {
-    Short(String),
+    Short(TcpAddress),
     Long(AddressStruct),
 }
 
@@ -61,205 +153,282 @@ pub enum WsPath {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Address {
-    /// Address to a TCP feed (e.g. `tcp://` defaults to the Norwegian AIS server, otherwise `tcp://ais.example.com:1234`)
-    Tcp(AddressPath),
-    /// Address to the Finnish Digitraffic MQTT broker (e.g. `mqtt://` defaults to `ship162` client ID, otherwise `mqtt://my_client_id`)
-    #[cfg(feature = "mqtt")]
-    Mqtt(String),
-    /// An RTL-SDR device, e.g. `rtlsdr://` or with structured config: `rtlsdr = { device = 0 }`
-    #[cfg(feature = "rtlsdr")]
-    Rtlsdr(RtlSdrPath),
-    /// A SoapySDR device, e.g. `soapy = "driver=rtlsdr"`
-    #[cfg(feature = "soapy")]
-    Soapy(SoapyPath),
-    /// An Airspy device, e.g. `airspy://` or with structured config: `airspy = { device = 0 }`
-    #[cfg(feature = "airspy")]
-    Airspy(AirspyPath),
-    /// A HackRF device, e.g. `hackrf://` or with structured config: `hackrf = { device = 0 }`
-    #[cfg(feature = "hackrf")]
-    Hackrf(HackrfPath),
-    /// A WebSocket source (e.g. `ws://host:port/path` or `{ url = "ws://...", jump = "host" }`)
-    Ws(WsPath),
-    /// An IQ file source
-    IqFile(String),
+#[serde(deny_unknown_fields)]
+pub struct TcpConfig {
+    /// Address to a TCP feed, either `host:port` or a structured endpoint
+    pub tcp: AddressPath,
+    /// Reconnect policy. Defaults to a fixed five-second delay when omitted
+    #[serde(default)]
+    pub retry: RetryPolicy,
 }
 
-/**
- * Describe sources of raw AIS data.
- *
- * Several sensors can be behind a single source of data.
- */
-#[derive(Debug, Clone, Serialize)]
-pub struct Source {
-    /// The address to the raw AIS data feed
-    #[serde(flatten)]
-    pub address: Address,
-    /// Gain setting for SDR devices (RTL-SDR/Soapy default: 49.6, Airspy default: auto)
-    #[cfg(any(
-        feature = "rtlsdr",
-        feature = "soapy",
-        feature = "airspy",
-        feature = "hackrf"
-    ))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WebSocketConfig {
+    /// WebSocket source URL, optionally with an SSH jump host
+    pub ws: WsPath,
+    /// Reconnect policy. Defaults to a fixed five-second delay when omitted
+    #[serde(default)]
+    pub retry: RetryPolicy,
+}
+
+#[cfg(feature = "mqtt")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MqttConfig {
+    /// Legacy MQTT source value
+    pub mqtt: String,
+    // TODO: model broker and client ID separately without breaking the accepted config.
+    // paho-mqtt manages reconnects internally so it doesn't have a retry policy
+}
+
+#[cfg(feature = "rtlsdr")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RtlSdrConfig {
+    /// RTL-SDR device selector and device-specific settings
+    pub rtlsdr: RtlSdrPath,
+    /// Gain setting. Defaults to the recommended AIS gain when omitted
     pub gain: Option<Gain>,
-    /// Sample rate in Hz (default depends on device)
-    #[cfg(any(
-        feature = "rtlsdr",
-        feature = "soapy",
-        feature = "airspy",
-        feature = "hackrf"
-    ))]
+    /// Sample rate in Hz. Defaults to 288 kHz when omitted
     pub sample_rate: Option<f64>,
-    /// Enable bias-tee to power external LNA (RTL-SDR/SoapySDR/Airspy/HackRF, default: false)
-    #[cfg(any(
-        feature = "rtlsdr",
-        feature = "soapy",
-        feature = "airspy",
-        feature = "hackrf"
-    ))]
+    /// Enable the bias tee to power an external LNA. Defaults to false
     pub bias_tee: Option<bool>,
 }
 
-// Custom deserializer to ensure proper validation
-impl<'de> Deserialize<'de> for Source {
+#[cfg(feature = "soapy")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SoapyConfig {
+    /// SoapySDR device arguments, for example `driver=rtlsdr`
+    pub soapy: SoapyPath,
+    /// Gain setting. Defaults to the recommended AIS gain when omitted
+    pub gain: Option<Gain>,
+    /// Sample rate in Hz. Defaults to 288 kHz when omitted
+    pub sample_rate: Option<f64>,
+    /// Enable the bias tee to power an external LNA. Defaults to false
+    pub bias_tee: Option<bool>,
+}
+
+#[cfg(feature = "airspy")]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AirspyConfig {
+    /// Airspy device selector and device-specific gain settings
+    pub airspy: AirspyPath,
+    /// Source-level gain setting. Cannot be combined with per-element gains
+    pub gain: Option<Gain>,
+    /// Sample rate in Hz. Defaults to 6 MHz when omitted
+    pub sample_rate: Option<f64>,
+    /// Enable the bias tee to power an external LNA. Defaults to false
+    pub bias_tee: Option<bool>,
+}
+
+#[cfg(feature = "airspy")]
+impl<'de> Deserialize<'de> for AirspyConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
-        struct SourceHelper {
-            #[serde(flatten)]
-            address: Address,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
+        struct Input {
+            airspy: AirspyPath,
             gain: Option<Gain>,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
             sample_rate: Option<f64>,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
             bias_tee: Option<bool>,
         }
 
-        let helper = SourceHelper::deserialize(deserializer)?;
-
-        // Validate that source-level gain and per-element device gains are not mixed
-        #[cfg(feature = "airspy")]
-        if helper.gain.is_some() {
-            if let Address::Airspy(ref path) = helper.address {
-                if path.config.lna_gain.is_some()
-                    || path.config.mixer_gain.is_some()
-                    || path.config.vga_gain.is_some()
-                {
-                    return Err(serde::de::Error::custom(
-                        "Cannot specify both `gain` (source level) and per-element gains \
-                         (`lna_gain`, `mixer_gain`, `vga_gain`) inside `airspy = { ... }`. \
-                         Use one or the other.",
-                    ));
-                }
-            }
-        }
-        #[cfg(feature = "hackrf")]
-        if helper.gain.is_some() {
-            if let Address::Hackrf(ref path) = helper.address {
-                if path.config.lna_gain.is_some() || path.config.vga_gain.is_some() {
-                    return Err(serde::de::Error::custom(
-                        "Cannot specify both `gain` (source level) and per-element gains \
-                         (`lna_gain`, `vga_gain`) inside `hackrf = { ... }`. \
-                         Use one or the other.",
-                    ));
-                }
-            }
+        let input = Input::deserialize(deserializer)?;
+        if input.gain.is_some()
+            && (input.airspy.config.lna_gain.is_some()
+                || input.airspy.config.mixer_gain.is_some()
+                || input.airspy.config.vga_gain.is_some())
+        {
+            return Err(serde::de::Error::custom(
+                "cannot specify both `gain` and per-element airspy gains",
+            ));
         }
 
-        Ok(Source {
-            address: helper.address,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
-            gain: helper.gain,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
-            sample_rate: helper.sample_rate,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
-            bias_tee: helper.bias_tee,
+        Ok(Self {
+            airspy: input.airspy,
+            gain: input.gain,
+            sample_rate: input.sample_rate,
+            bias_tee: input.bias_tee,
         })
     }
 }
 
+#[cfg(feature = "hackrf")]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct HackRfConfig {
+    /// HackRF device selector and device-specific gain settings
+    pub hackrf: HackrfPath,
+    /// Source-level gain setting. Cannot be combined with per-element gains
+    pub gain: Option<Gain>,
+    /// Sample rate in Hz. Defaults to 288 kHz when omitted
+    pub sample_rate: Option<f64>,
+    /// Enable the antenna power output. Defaults to false
+    pub bias_tee: Option<bool>,
+}
+
+#[cfg(feature = "hackrf")]
+impl<'de> Deserialize<'de> for HackRfConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Input {
+            hackrf: HackrfPath,
+            gain: Option<Gain>,
+            sample_rate: Option<f64>,
+            bias_tee: Option<bool>,
+        }
+
+        let input = Input::deserialize(deserializer)?;
+        if input.gain.is_some()
+            && (input.hackrf.config.lna_gain.is_some() || input.hackrf.config.vga_gain.is_some())
+        {
+            return Err(serde::de::Error::custom(
+                "cannot specify both `gain` and per-element hackrf gains",
+            ));
+        }
+
+        Ok(Self {
+            hackrf: input.hackrf,
+            gain: input.gain,
+            sample_rate: input.sample_rate,
+            bias_tee: input.bias_tee,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IqFileConfig {
+    /// Path to a CU8 IQ recording replayed at 288 kHz
+    pub iqfile: String,
+}
+
+#[derive(Debug, Error)]
+pub enum SourceParseError {
+    #[error("invalid source `{value}`: {source}")]
+    InvalidUrl {
+        value: String,
+        #[source]
+        source: url::ParseError,
+    },
+    #[error(transparent)]
+    TcpAddress(#[from] TcpAddressError),
+    #[cfg_attr(
+        all(
+            feature = "mqtt",
+            feature = "rtlsdr",
+            feature = "soapy",
+            feature = "airspy",
+            feature = "hackrf"
+        ),
+        allow(dead_code)
+    )]
+    #[error("{source_name} support is not enabled; compile with --features {feature}")]
+    FeatureDisabled {
+        source_name: &'static str,
+        feature: &'static str,
+    },
+    #[error("invalid file URL `{0}`")]
+    InvalidFileUrl(Url),
+    #[error("unsupported source scheme `{0}`")]
+    UnsupportedScheme(String),
+}
+
+// TODO: normalize endpoints and SDR defaults during source parsing
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Source {
+    Tcp(TcpConfig),
+    WebSocket(WebSocketConfig),
+    #[cfg(feature = "mqtt")]
+    Mqtt(MqttConfig),
+    #[cfg(feature = "rtlsdr")]
+    RtlSdr(RtlSdrConfig),
+    #[cfg(feature = "soapy")]
+    Soapy(SoapyConfig),
+    #[cfg(feature = "airspy")]
+    Airspy(AirspyConfig),
+    #[cfg(feature = "hackrf")]
+    HackRf(HackRfConfig),
+    IqFile(IqFileConfig),
+}
+
 impl FromStr for Source {
-    type Err = String;
+    type Err = SourceParseError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let default_tcp = Url::parse("tcp://").unwrap();
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let default_tcp = Url::parse("tcp://").expect("static tcp base url is valid");
+        let url = default_tcp
+            .join(value)
+            .map_err(|source| SourceParseError::InvalidUrl {
+                value: value.to_string(),
+                source,
+            })?;
 
-        let url = default_tcp.join(s).map_err(|e| e.to_string())?;
-
-        let address = match url.scheme() {
-            "tcp" => Address::Tcp(AddressPath::Short(format!(
-                "{}:{}",
-                url.host_str().unwrap_or("153.44.253.27"),
-                url.port_or_known_default().unwrap_or(5631),
-            ))),
-            #[cfg(feature = "mqtt")]
-            "mqtt" => Address::Mqtt(url.host_str().unwrap_or("ship162").to_string()),
-            #[cfg(not(feature = "mqtt"))]
-            "mqtt" => {
-                return Err("MQTT support is not enabled. Compile with --features mqtt".to_string())
-            }
-            #[cfg(feature = "rtlsdr")]
-            "rtlsdr" => {
-                // Parse rtlsdr:// URL - default to device 0
-                let config = RtlSdrDeviceConfig {
-                    device: Some(0),
-                    serial: None,
-                    manufacturer: None,
-                    product: None,
+        // for simplicity we don't parse the retry logic from the source uri, just let TOML handle it
+        match url.scheme() {
+            "tcp" => {
+                let host = url.host_str().unwrap_or("153.44.253.27");
+                let port = url.port_or_known_default().unwrap_or(5631);
+                let address = if host.contains(':') {
+                    format!("[{host}]:{port}")
+                } else {
+                    format!("{host}:{port}")
                 };
-                Address::Rtlsdr(RtlSdrPath { config })
+                Ok(Self::Tcp(TcpConfig {
+                    tcp: AddressPath::Short(address.parse()?),
+                    retry: RetryPolicy::default(),
+                }))
             }
+            #[cfg(feature = "mqtt")]
+            "mqtt" => Ok(Self::Mqtt(MqttConfig {
+                mqtt: url.host_str().unwrap_or("ship162").to_string(),
+            })),
+            #[cfg(not(feature = "mqtt"))]
+            "mqtt" => Err(SourceParseError::FeatureDisabled {
+                source_name: "MQTT",
+                feature: "mqtt",
+            }),
+            #[cfg(feature = "rtlsdr")]
+            "rtlsdr" => Ok(Self::RtlSdr(RtlSdrConfig {
+                rtlsdr: RtlSdrPath {
+                    config: RtlSdrDeviceConfig {
+                        device: Some(0),
+                        serial: None,
+                        manufacturer: None,
+                        product: None,
+                    },
+                },
+                gain: None,
+                sample_rate: None,
+                bias_tee: None,
+            })),
             #[cfg(not(feature = "rtlsdr"))]
-            "rtlsdr" => {
-                return Err(
-                    "RTL-SDR support is not enabled. Compile with --features rtlsdr".to_string(),
-                )
-            }
+            "rtlsdr" => Err(SourceParseError::FeatureDisabled {
+                source_name: "RTL-SDR",
+                feature: "rtlsdr",
+            }),
             #[cfg(feature = "soapy")]
-            "soapy" => {
-                let args = url.host_str().unwrap_or("driver=rtlsdr").to_string();
-                Address::Soapy(SoapyPath { soapy: args })
-            }
+            "soapy" => Ok(Self::Soapy(SoapyConfig {
+                soapy: SoapyPath {
+                    soapy: url.host_str().unwrap_or("driver=rtlsdr").to_string(),
+                },
+                gain: None,
+                sample_rate: None,
+                bias_tee: None,
+            })),
             #[cfg(feature = "airspy")]
             "airspy" => {
-                let device_str = url.host_str().unwrap_or("");
-                let config = if device_str.is_empty() {
+                let device = url.host_str().unwrap_or("");
+                let config = if device.is_empty() {
                     AirspyDeviceConfig {
                         device: Some(0),
                         serial: None,
@@ -267,15 +436,15 @@ impl FromStr for Source {
                         mixer_gain: None,
                         vga_gain: None,
                     }
-                } else if let Ok(idx) = device_str.parse::<usize>() {
+                } else if let Ok(index) = device.parse::<usize>() {
                     AirspyDeviceConfig {
-                        device: Some(idx),
+                        device: Some(index),
                         serial: None,
                         lna_gain: None,
                         mixer_gain: None,
                         vga_gain: None,
                     }
-                } else if let Some(serial) = device_str.strip_prefix("serial=") {
+                } else if let Some(serial) = device.strip_prefix("serial=") {
                     AirspyDeviceConfig {
                         device: None,
                         serial: Some(serial.to_string()),
@@ -284,11 +453,11 @@ impl FromStr for Source {
                         vga_gain: None,
                     }
                 } else {
+                    // TODO: return a parse error instead of warning and defaulting
                     eprintln!(
-                        "WARNING: Unrecognized Airspy device format: '{}'\n\
+                        "WARNING: Unrecognized Airspy device format: '{device}'\n\
                          Expected device index (0, 1, 2, ...) or 'serial=...'.\n\
-                         Defaulting to device 0.",
-                        device_str
+                         Defaulting to device 0."
                     );
                     AirspyDeviceConfig {
                         device: Some(0),
@@ -298,104 +467,76 @@ impl FromStr for Source {
                         vga_gain: None,
                     }
                 };
-                Address::Airspy(AirspyPath { config })
-            }
 
+                Ok(Self::Airspy(AirspyConfig {
+                    airspy: AirspyPath { config },
+                    gain: None,
+                    sample_rate: None,
+                    bias_tee: None,
+                }))
+            }
             #[cfg(feature = "hackrf")]
             "hackrf" => {
-                let device_str = url.host_str().unwrap_or("");
-                let config = if device_str.is_empty() {
-                    HackrfDeviceConfig {
-                        device: Some(0),
-                        amp_enable: None,
-                        lna_gain: None,
-                        vga_gain: None,
-                        freq_offset_hz: None,
-                    }
-                } else if let Ok(idx) = device_str.parse::<usize>() {
-                    HackrfDeviceConfig {
-                        device: Some(idx),
-                        amp_enable: None,
-                        lna_gain: None,
-                        vga_gain: None,
-                        freq_offset_hz: None,
-                    }
+                let device = url.host_str().unwrap_or("");
+                let device = if device.is_empty() {
+                    0
+                } else if let Ok(index) = device.parse::<usize>() {
+                    index
                 } else {
+                    // TODO: return a parse error instead of warning and defaulting
                     eprintln!(
-                        "WARNING: Unrecognized HackRF device format: '{}'\n\
+                        "WARNING: Unrecognized HackRF device format: '{device}'\n\
                          Expected device index (0, 1, 2, ...).\n\
-                         Defaulting to device 0.",
-                        device_str
+                         Defaulting to device 0."
                     );
-                    HackrfDeviceConfig {
-                        device: Some(0),
-                        amp_enable: None,
-                        lna_gain: None,
-                        vga_gain: None,
-                        freq_offset_hz: None,
-                    }
+                    0
                 };
-                Address::Hackrf(HackrfPath { config })
+
+                Ok(Self::HackRf(HackRfConfig {
+                    hackrf: HackrfPath {
+                        config: HackrfDeviceConfig {
+                            device: Some(device),
+                            amp_enable: None,
+                            lna_gain: None,
+                            vga_gain: None,
+                            freq_offset_hz: None,
+                        },
+                    },
+                    gain: None,
+                    sample_rate: None,
+                    bias_tee: None,
+                }))
             }
             #[cfg(not(feature = "soapy"))]
-            "soapy" => {
-                return Err(
-                    "SoapySDR support is not enabled. Compile with --features soapy".to_string(),
-                )
-            }
+            "soapy" => Err(SourceParseError::FeatureDisabled {
+                source_name: "SoapySDR",
+                feature: "soapy",
+            }),
             #[cfg(not(feature = "airspy"))]
-            "airspy" => {
-                return Err(
-                    "Airspy support is not enabled. Compile with --features airspy".to_string(),
-                )
-            }
+            "airspy" => Err(SourceParseError::FeatureDisabled {
+                source_name: "Airspy",
+                feature: "airspy",
+            }),
             #[cfg(not(feature = "hackrf"))]
-            "hackrf" => {
-                return Err(
-                    "HackRF support is not enabled. Compile with --features hackrf".to_string(),
-                )
-            }
-
-            "ws" | "wss" => Address::Ws(WsPath::Short(s.to_string())),
-
-            "file" => {
-                let path = url
+            "hackrf" => Err(SourceParseError::FeatureDisabled {
+                source_name: "HackRF",
+                feature: "hackrf",
+            }),
+            "ws" | "wss" => Ok(Self::WebSocket(WebSocketConfig {
+                ws: WsPath::Short(value.to_string()),
+                retry: RetryPolicy::default(),
+            })),
+            "file" => Ok(Self::IqFile(IqFileConfig {
+                iqfile: url
                     .to_file_path()
-                    .map_err(|_| "invalid file path".to_string())?
+                    .map_err(|_| SourceParseError::InvalidFileUrl(url.clone()))?
                     .to_string_lossy()
-                    .to_string();
-                Address::IqFile(path)
-            }
-
-            _ => return Err("unsupported scheme".to_string()),
-        };
-
-        let source = Source {
-            address,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
-            gain: None,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
-            sample_rate: None,
-            #[cfg(any(
-                feature = "rtlsdr",
-                feature = "soapy",
-                feature = "airspy",
-                feature = "hackrf"
-            ))]
-            bias_tee: None,
-        };
-
-        Ok(source)
+                    .into_owned(),
+            })),
+            _ => Err(SourceParseError::UnsupportedScheme(
+                url.scheme().to_string(),
+            )),
+        }
     }
 }
 
@@ -538,281 +679,334 @@ pub async fn process_sentence(mut state: MutexGuard<'_, AppState>, sentence: &mu
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
-    #[test]
-    fn test_toml_rtlsdr_device_index() {
-        #[cfg(feature = "rtlsdr")]
-        {
-            let toml = r#"
-                rtlsdr = { device = 0 }
-                gain = 49.6
-            "#;
-            let source: Source =
-                toml::from_str(toml).expect("Failed to parse RTL-SDR with device index");
-            assert!(matches!(source.address, Address::Rtlsdr(_)));
-            if let Address::Rtlsdr(path) = &source.address {
-                assert_eq!(path.config.device, Some(0));
-                assert_eq!(path.config.serial, None);
+    macro_rules! unwrap_source {
+        ($source:expr, $variant:ident) => {
+            match $source {
+                Source::$variant(config) => config,
+                source => panic!(
+                    "expected {} source, got {source:?}",
+                    stringify!($variant).to_lowercase()
+                ),
             }
-            assert_eq!(source.gain, Some(Gain::Manual(49.6)));
-        }
+        };
     }
 
+    #[cfg(feature = "rtlsdr")]
+    #[test]
+    fn test_toml_rtlsdr_device_index() {
+        let source: Source = toml::from_str(
+            r#"
+                rtlsdr = { device = 0 }
+                gain = 49.6
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, RtlSdr);
+        assert_eq!(config.rtlsdr.config.device, Some(0));
+        assert_eq!(config.rtlsdr.config.serial, None);
+        assert_eq!(config.gain, Some(Gain::Manual(49.6)));
+    }
+
+    #[cfg(feature = "rtlsdr")]
     #[test]
     fn test_toml_rtlsdr_serial() {
-        #[cfg(feature = "rtlsdr")]
-        {
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 rtlsdr = { serial = "00000001" }
                 gain = 49.6
                 bias_tee = true
-            "#;
-            let source: Source = toml::from_str(toml).expect("Failed to parse RTL-SDR with serial");
-            if let Address::Rtlsdr(path) = &source.address {
-                assert_eq!(path.config.device, None);
-                assert_eq!(path.config.serial, Some("00000001".to_string()));
-            }
-            assert_eq!(source.gain, Some(Gain::Manual(49.6)));
-            assert_eq!(source.bias_tee, Some(true));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, RtlSdr);
+        assert_eq!(config.rtlsdr.config.device, None);
+        assert_eq!(config.rtlsdr.config.serial.as_deref(), Some("00000001"));
+        assert_eq!(config.gain, Some(Gain::Manual(49.6)));
+        assert_eq!(config.bias_tee, Some(true));
     }
 
+    #[cfg(feature = "rtlsdr")]
     #[test]
     fn test_toml_rtlsdr_all_filters() {
-        #[cfg(feature = "rtlsdr")]
-        {
-            let toml = r#"
-                rtlsdr = { 
-                    serial = "00000001", 
-                    manufacturer = "Realtek", 
-                    product = "RTL2838UHIDIR" 
+        let source: Source = toml::from_str(
+            r#"
+                rtlsdr = {
+                    serial = "00000001",
+                    manufacturer = "Realtek",
+                    product = "RTL2838UHIDIR"
                 }
-            "#;
-            let source: Source =
-                toml::from_str(toml).expect("Failed to parse RTL-SDR with all filters");
-            if let Address::Rtlsdr(path) = &source.address {
-                assert_eq!(path.config.serial, Some("00000001".to_string()));
-                assert_eq!(path.config.manufacturer, Some("Realtek".to_string()));
-                assert_eq!(path.config.product, Some("RTL2838UHIDIR".to_string()));
-            }
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, RtlSdr);
+        assert_eq!(config.rtlsdr.config.serial.as_deref(), Some("00000001"));
+        assert_eq!(
+            config.rtlsdr.config.manufacturer.as_deref(),
+            Some("Realtek")
+        );
+        assert_eq!(
+            config.rtlsdr.config.product.as_deref(),
+            Some("RTL2838UHIDIR")
+        );
     }
 
+    #[cfg(feature = "rtlsdr")]
     #[test]
     fn test_toml_rtlsdr_with_sample_rate() {
-        #[cfg(feature = "rtlsdr")]
-        {
-            // sample_rate is at source level, not inside rtlsdr = { ... }
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 rtlsdr = { device = 0 }
                 sample_rate = 1536000
                 gain = 49.6
-            "#;
-            let source: Source =
-                toml::from_str(toml).expect("Failed to parse RTL-SDR with sample_rate");
-            assert_eq!(source.sample_rate, Some(1536000.0));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, RtlSdr);
+        assert_eq!(config.sample_rate, Some(1_536_000.0));
     }
 
+    #[cfg(feature = "soapy")]
     #[test]
     fn test_toml_soapy() {
-        #[cfg(feature = "soapy")]
-        {
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 soapy = "driver=rtlsdr"
                 gain = 49.6
                 bias_tee = false
-            "#;
-            let source: Source = toml::from_str(toml).expect("Failed to parse SoapySDR");
-            if let Address::Soapy(path) = &source.address {
-                assert_eq!(path.soapy, "driver=rtlsdr");
-            }
-            assert_eq!(source.gain, Some(Gain::Manual(49.6)));
-            assert_eq!(source.bias_tee, Some(false));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, Soapy);
+        assert_eq!(config.soapy.soapy, "driver=rtlsdr");
+        assert_eq!(config.gain, Some(Gain::Manual(49.6)));
+        assert_eq!(config.bias_tee, Some(false));
     }
 
+    #[cfg(feature = "soapy")]
     #[test]
     fn test_toml_soapy_with_sample_rate() {
-        #[cfg(feature = "soapy")]
-        {
-            // sample_rate is at source level, not inside soapy = "..."
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 soapy = "driver=airspy"
                 sample_rate = 3000000
                 gain = 49.6
-            "#;
-            let source: Source = toml::from_str(toml).expect("Failed to parse Airspy via SoapySDR");
-            if let Address::Soapy(path) = &source.address {
-                assert_eq!(path.soapy, "driver=airspy");
-            }
-            assert_eq!(source.sample_rate, Some(3000000.0));
-            assert_eq!(source.gain, Some(Gain::Manual(49.6)));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, Soapy);
+        assert_eq!(config.soapy.soapy, "driver=airspy");
+        assert_eq!(config.sample_rate, Some(3_000_000.0));
+        assert_eq!(config.gain, Some(Gain::Manual(49.6)));
     }
 
+    #[cfg(feature = "airspy")]
     #[test]
     fn test_toml_airspy() {
-        #[cfg(feature = "airspy")]
-        {
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 airspy = { device = 0 }
                 gain = "auto"
                 bias_tee = true
-            "#;
-            let source: Source = toml::from_str(toml).expect("Failed to parse Airspy TOML");
-            if let Address::Airspy(path) = &source.address {
-                assert_eq!(path.config.device, Some(0));
-                assert_eq!(path.config.serial, None);
-            }
-            assert_eq!(source.gain, Some(Gain::Auto));
-            assert_eq!(source.bias_tee, Some(true));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, Airspy);
+        assert_eq!(config.airspy.config.device, Some(0));
+        assert_eq!(config.airspy.config.serial, None);
+        assert_eq!(config.gain, Some(Gain::Auto));
+        assert_eq!(config.bias_tee, Some(true));
     }
 
+    #[cfg(feature = "airspy")]
     #[test]
     fn test_toml_airspy_with_sample_rate() {
-        #[cfg(feature = "airspy")]
-        {
-            // sample_rate is at source level, not inside airspy = { ... }
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 airspy = { device = 0 }
                 sample_rate = 6000000
                 gain = "auto"
-            "#;
-            let source: Source =
-                toml::from_str(toml).expect("Failed to parse Airspy with sample_rate");
-            assert_eq!(source.sample_rate, Some(6000000.0));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, Airspy);
+        assert_eq!(config.sample_rate, Some(6_000_000.0));
     }
 
+    #[cfg(feature = "hackrf")]
     #[test]
     fn test_toml_hackrf() {
-        #[cfg(feature = "hackrf")]
-        {
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 hackrf = { device = 0 }
                 gain = "auto"
-            "#;
-            let source: Source = toml::from_str(toml).expect("Failed to parse HackRF TOML");
-            if let Address::Hackrf(path) = &source.address {
-                assert_eq!(path.config.device, Some(0));
-                assert_eq!(path.config.amp_enable, None);
-            }
-            assert_eq!(source.gain, Some(Gain::Auto));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, HackRf);
+        assert_eq!(config.hackrf.config.device, Some(0));
+        assert_eq!(config.hackrf.config.amp_enable, None);
+        assert_eq!(config.gain, Some(Gain::Auto));
     }
 
+    #[cfg(feature = "hackrf")]
     #[test]
     fn test_toml_hackrf_with_amp() {
-        #[cfg(feature = "hackrf")]
-        {
-            let toml = r#"
+        let source: Source = toml::from_str(
+            r#"
                 hackrf = { device = 0, amp_enable = true }
                 bias_tee = false
-            "#;
-            let source: Source =
-                toml::from_str(toml).expect("Failed to parse HackRF with amp_enable");
-            if let Address::Hackrf(path) = &source.address {
-                assert_eq!(path.config.device, Some(0));
-                assert_eq!(path.config.amp_enable, Some(true));
-            }
-            assert_eq!(source.bias_tee, Some(false));
-        }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, HackRf);
+        assert_eq!(config.hackrf.config.device, Some(0));
+        assert_eq!(config.hackrf.config.amp_enable, Some(true));
+        assert_eq!(config.bias_tee, Some(false));
     }
 
     #[test]
     fn test_toml_tcp() {
-        let toml = r#"
-            tcp = "153.44.253.27:5631"
-        "#;
-        let source: Source = toml::from_str(toml).expect("Failed to parse TCP source");
-        assert!(matches!(source.address, Address::Tcp(_)));
+        let source: Source = toml::from_str(
+            r#"
+                tcp = "153.44.253.27:5631"
+                retry = { strategy = "fixed", delay_seconds = 2.5 }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(&source, Tcp);
+        let AddressPath::Short(address) = &config.tcp else {
+            panic!("expected short TCP address");
+        };
+        assert_eq!(address.host, "153.44.253.27");
+        assert_eq!(address.port.get(), 5631);
+        let RetryPolicy::Fixed { delay } = config.retry;
+        assert_eq!(delay.duration(), Duration::from_millis(2500));
+
+        let serialized = toml::to_string(&source).unwrap();
+        let roundtrip: Source = toml::from_str(&serialized).unwrap();
+        assert_eq!(source, roundtrip);
+    }
+
+    #[cfg(feature = "mqtt")]
+    #[test]
+    fn test_toml_mqtt() {
+        let source: Source = toml::from_str(r#"mqtt = "mqtt://mqtt.digitraffic.fi""#).unwrap();
+        let config = unwrap_source!(source, Mqtt);
+        assert_eq!(config.mqtt, "mqtt://mqtt.digitraffic.fi");
     }
 
     #[test]
-    fn test_toml_mqtt() {
-        #[cfg(feature = "mqtt")]
-        {
-            let toml = r#"
-                mqtt = "ship162_client"
-            "#;
-            let source: Source = toml::from_str(toml).expect("Failed to parse MQTT source");
-            if let Address::Mqtt(client_id) = &source.address {
-                assert_eq!(client_id, "ship162_client");
-            }
-        }
+    fn test_invalid_tcp_address() {
+        assert!(matches!(
+            "localhost".parse::<TcpAddress>(),
+            Err(TcpAddressError::TcpPortMissing { .. })
+        ));
+        assert!(matches!(
+            "localhost:0".parse::<TcpAddress>(),
+            Err(TcpAddressError::TcpPortInvalid { .. })
+        ));
+        assert!(matches!(
+            "localhost:not-a-port".parse::<TcpAddress>(),
+            Err(TcpAddressError::TcpPortInvalid { .. })
+        ));
+        assert!(matches!(
+            "::1:5631".parse::<TcpAddress>(),
+            Err(TcpAddressError::TcpIpv6NotBracketed { .. })
+        ));
+
+        assert!(toml::from_str::<Source>("tcp = { host = \"localhost\", port = 0 }").is_err());
+        assert!(matches!(
+            Source::from_str("tcp://localhost:0"),
+            Err(SourceParseError::TcpAddress(
+                TcpAddressError::TcpPortInvalid { .. }
+            ))
+        ));
+        assert!(matches!(
+            Source::from_str("ftp://example.com/source"),
+            Err(SourceParseError::UnsupportedScheme(scheme)) if scheme == "ftp"
+        ));
+    }
+
+    #[test]
+    fn test_toml_websocket() {
+        let source: Source = toml::from_str(
+            r#"
+                ws = "ws://localhost:9876"
+                retry = { strategy = "fixed", delay_seconds = 3 }
+            "#,
+        )
+        .unwrap();
+        let config = unwrap_source!(source, WebSocket);
+        let RetryPolicy::Fixed { delay } = config.retry;
+        assert_eq!(delay.duration(), Duration::from_secs(3));
     }
 
     #[test]
     fn test_toml_iqfile() {
-        let toml = r#"
-            iqfile = "/path/to/recording.iq"
-        "#;
-        let source: Source = toml::from_str(toml).expect("Failed to parse IQ file source");
-        if let Address::IqFile(path) = &source.address {
-            assert_eq!(path, "/path/to/recording.iq");
-        }
+        let source: Source = toml::from_str(r#"iqfile = "/path/to/recording.iq""#).unwrap();
+        let config = unwrap_source!(source, IqFile);
+        assert_eq!(config.iqfile, "/path/to/recording.iq");
     }
 
+    #[cfg(feature = "rtlsdr")]
     #[test]
     fn test_toml_unknown_field_rejected() {
-        #[cfg(feature = "rtlsdr")]
-        {
-            let toml = r#"
-                rtlsdr = { device = 0, invalid_field = "foo" }
-            "#;
-            let result: Result<Source, _> = toml::from_str(toml);
-            assert!(result.is_err(), "Unknown field should be rejected");
-        }
+        let result: Result<Source, _> = toml::from_str(
+            r#"
+                rtlsdr = { device = 0 }
+                invalid_field = "foo"
+            "#,
+        );
+        assert!(result.is_err());
     }
 
     #[test]
     fn test_url_backward_compatibility() {
         #[cfg(feature = "rtlsdr")]
         {
-            let source = Source::from_str("rtlsdr://").expect("Failed to parse rtlsdr:// URL");
-            if let Address::Rtlsdr(path) = &source.address {
-                assert_eq!(path.config.device, Some(0));
-            }
+            let source = Source::from_str("rtlsdr://").unwrap();
+            let config = unwrap_source!(source, RtlSdr);
+            assert_eq!(config.rtlsdr.config.device, Some(0));
         }
 
-        let source = Source::from_str("tcp://153.44.253.27:5631").expect("Failed to parse TCP URL");
-        assert!(matches!(source.address, Address::Tcp(_)));
+        let source = Source::from_str("tcp://153.44.253.27:5631").unwrap();
+        let config = unwrap_source!(source, Tcp);
+        let RetryPolicy::Fixed { delay } = config.retry;
+        assert_eq!(delay.duration(), Duration::from_secs(5));
 
         #[cfg(feature = "airspy")]
         {
-            let source = Source::from_str("airspy://").expect("Failed to parse airspy:// URL");
-            if let Address::Airspy(path) = &source.address {
-                assert_eq!(path.config.device, Some(0));
-                assert_eq!(path.config.serial, None);
-            }
+            let source = Source::from_str("airspy://").unwrap();
+            let config = unwrap_source!(source, Airspy);
+            assert_eq!(config.airspy.config.device, Some(0));
+            assert_eq!(config.airspy.config.serial, None);
 
-            let source = Source::from_str("airspy://1").expect("Failed to parse airspy://1 URL");
-            if let Address::Airspy(path) = &source.address {
-                assert_eq!(path.config.device, Some(1));
-            }
+            let source = Source::from_str("airspy://1").unwrap();
+            let config = unwrap_source!(source, Airspy);
+            assert_eq!(config.airspy.config.device, Some(1));
 
-            let source = Source::from_str("airspy://serial=0x35AC63DC2D8C7A4F")
-                .expect("Failed to parse airspy serial URL");
-            if let Address::Airspy(path) = &source.address {
-                assert_eq!(path.config.device, None);
-                assert_eq!(path.config.serial, Some("0x35AC63DC2D8C7A4F".to_string()));
-            }
+            let source = Source::from_str("airspy://serial=0x35AC63DC2D8C7A4F").unwrap();
+            let config = unwrap_source!(source, Airspy);
+            assert_eq!(config.airspy.config.device, None);
+            assert_eq!(
+                config.airspy.config.serial.as_deref(),
+                Some("0x35AC63DC2D8C7A4F")
+            );
         }
 
         #[cfg(feature = "hackrf")]
         {
-            let source = Source::from_str("hackrf://").expect("Failed to parse hackrf:// URL");
-            if let Address::Hackrf(path) = &source.address {
-                assert_eq!(path.config.device, Some(0));
-            }
+            let source = Source::from_str("hackrf://").unwrap();
+            let config = unwrap_source!(source, HackRf);
+            assert_eq!(config.hackrf.config.device, Some(0));
 
-            let source = Source::from_str("hackrf://1").expect("Failed to parse hackrf://1 URL");
-            if let Address::Hackrf(path) = &source.address {
-                assert_eq!(path.config.device, Some(1));
-            }
+            let source = Source::from_str("hackrf://1").unwrap();
+            let config = unwrap_source!(source, HackRf);
+            assert_eq!(config.hackrf.config.device, Some(1));
         }
     }
 }

--- a/crates/ship162/src/sources/mqtt.rs
+++ b/crates/ship162/src/sources/mqtt.rs
@@ -18,10 +18,10 @@ impl MqttSource {
         loop {
             match self.connect_and_process().await {
                 Ok(_) => {
-                    eprintln!("Connection closed, reconnecting...");
+                    tracing::warn!("Connection closed, reconnecting...");
                 }
                 Err(e) => {
-                    eprintln!("Error: {}, reconnecting in 5 seconds...", e);
+                    tracing::warn!("Error: {}, reconnecting in 5 seconds...", e);
                     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                 }
             }

--- a/crates/ship162/src/sources/mqtt.rs
+++ b/crates/ship162/src/sources/mqtt.rs
@@ -1,6 +1,6 @@
+use anyhow::Result;
 use rs162::sources::mqtt::MqttReceiver;
 use tokio::sync::mpsc::Sender;
-use tracing::info;
 
 use crate::sources::TimedMessage;
 
@@ -14,35 +14,24 @@ impl MqttSource {
         Self { tx, broker_url }
     }
 
-    pub async fn run(&self) -> anyhow::Result<()> {
-        loop {
-            match self.connect_and_process().await {
-                Ok(_) => {
-                    tracing::warn!("Connection closed, reconnecting...");
-                }
-                Err(e) => {
-                    tracing::warn!("Error: {}, reconnecting in 5 seconds...", e);
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                }
-            }
-        }
-    }
-
-    async fn connect_and_process(&self) -> anyhow::Result<()> {
+    pub async fn run(&self) -> Result<()> {
+        // TODO: this is a bug in f27b429, passing broker_url to client_id is wrong
+        // rs162 should allow configuring broker, tos and topic
         let mut source = MqttReceiver::new(&self.broker_url).await?;
 
-        info!("Connected to MQTT broker at {}", self.broker_url);
-        while let Some(msg) = source.next().await {
-            if let Ok(msg) = msg {
-                let sentence = super::TimedMessage {
-                    timestamp: msg.timestamp,
+        while let Some(message) = source.next().await {
+            let Ok(message) = message else {
+                continue;
+            };
+            self.tx
+                .send(TimedMessage {
+                    timestamp: message.timestamp,
                     signal_level: None,
-                    message: msg.message,
+                    message: message.message,
                     mmsi_info: None,
                     nmea_sentences: vec![],
-                };
-                self.tx.send(sentence).await?;
-            }
+                })
+                .await?;
         }
         Ok(())
     }

--- a/crates/ship162/src/sources/tcp.rs
+++ b/crates/ship162/src/sources/tcp.rs
@@ -3,15 +3,18 @@ use anyhow::Result;
 use rs162::sources::nmea_ts::AsyncTimestampedNmeaSource;
 use rs162::sources::nmea_ts::AsyncTimestampedNmeaTcpSource;
 use tokio::sync::mpsc::Sender;
-use tracing::info;
 
 #[cfg(feature = "ssh")]
 use rs162::sources::ssh::TunnelledTcp;
 
-use crate::sources::TimedMessage;
+use crate::{
+    sources::TimedMessage,
+    status::{ReconnectingSource, SourceRuntime, SourceStatus},
+};
 
 pub struct TcpSource {
     tx: Sender<TimedMessage>,
+    runtime: SourceRuntime,
     host: String,
     port: u16,
     #[cfg(feature = "ssh")]
@@ -19,9 +22,10 @@ pub struct TcpSource {
 }
 
 impl TcpSource {
-    pub fn new(tx: Sender<TimedMessage>, host: String, port: u16) -> Self {
+    pub fn new(tx: Sender<TimedMessage>, runtime: SourceRuntime, host: String, port: u16) -> Self {
         Self {
             tx,
+            runtime,
             host,
             port,
             #[cfg(feature = "ssh")]
@@ -30,37 +34,31 @@ impl TcpSource {
     }
 
     #[cfg(feature = "ssh")]
-    pub fn with_jump(tx: Sender<TimedMessage>, host: String, port: u16, jump: String) -> Self {
+    pub fn with_jump(
+        tx: Sender<TimedMessage>,
+        runtime: SourceRuntime,
+        host: String,
+        port: u16,
+        jump: String,
+    ) -> Self {
         Self {
             tx,
+            runtime,
             host,
             port,
             jump: Some(jump),
         }
     }
+}
 
-    pub async fn run(&self) -> Result<()> {
-        loop {
-            match self.connect_and_process().await {
-                Ok(_) => {
-                    tracing::warn!("Connection closed, reconnecting...");
-                }
-                Err(e) => {
-                    tracing::warn!("Error: {}, reconnecting in 5 seconds...", e);
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                }
-            }
-        }
+impl ReconnectingSource for TcpSource {
+    fn runtime(&self) -> &SourceRuntime {
+        &self.runtime
     }
 
-    async fn connect_and_process(&self) -> Result<()> {
+    async fn connect_once(&self) -> Result<()> {
         #[cfg(feature = "ssh")]
         if let Some(jump) = &self.jump {
-            // SSH tunnelled connection
-            info!(
-                "Connecting to {}:{} via SSH tunnel through {}",
-                self.host, self.port, jump
-            );
             let tunnel = TunnelledTcp {
                 address: self.host.clone(),
                 port: self.port,
@@ -69,49 +67,57 @@ impl TcpSource {
             let tunnel_reader = tunnel
                 .connect()
                 .await
-                .map_err(|e| anyhow::anyhow!("{}", e))?;
+                .map_err(|error| anyhow::anyhow!("{error}"))?;
+            tracing::info!(
+                host = self.host.as_str(),
+                port = self.port,
+                jump,
+                "ssh tunnel established"
+            );
             let buf_reader = tokio::io::BufReader::new(tunnel_reader);
             let mut source = AsyncTimestampedNmeaSource::from_reader(buf_reader);
 
-            info!("Connected to {}:{} via tunnel", self.host, self.port);
-
+            self.runtime.report(SourceStatus::Connected);
             while let Some(line) = source.next().await {
-                if let Ok(sentence) = line {
-                    if let Some(message) = sentence.decode() {
-                        let sentence = super::TimedMessage {
-                            timestamp: sentence.timestamp,
-                            signal_level: None,
-                            message,
-                            mmsi_info: None,
-                            nmea_sentences: vec![],
-                        };
-                        self.tx.send(sentence).await?;
-                    }
-                }
-            }
-
-            return Ok(());
-        }
-
-        // Regular TCP connection
-        let mut source =
-            AsyncTimestampedNmeaTcpSource::new(&format!("{}:{}", self.host, self.port)).await?;
-
-        info!("Connected to {}:{}", self.host, self.port);
-
-        while let Some(line) = source.next().await {
-            if let Ok(sentence) = line {
-                if let Some(message) = sentence.decode() {
-                    let sentence = super::TimedMessage {
+                let Ok(sentence) = line else {
+                    continue;
+                };
+                let Some(message) = sentence.decode() else {
+                    continue;
+                };
+                self.tx
+                    .send(super::TimedMessage {
                         timestamp: sentence.timestamp,
                         signal_level: None,
                         message,
                         mmsi_info: None,
                         nmea_sentences: vec![],
-                    };
-                    self.tx.send(sentence).await?;
-                }
+                    })
+                    .await?;
             }
+            return Ok(());
+        }
+
+        let mut source =
+            AsyncTimestampedNmeaTcpSource::new(&format!("{}:{}", self.host, self.port)).await?;
+
+        self.runtime.report(SourceStatus::Connected);
+        while let Some(line) = source.next().await {
+            let Ok(sentence) = line else {
+                continue;
+            };
+            let Some(message) = sentence.decode() else {
+                continue;
+            };
+            self.tx
+                .send(super::TimedMessage {
+                    timestamp: sentence.timestamp,
+                    signal_level: None,
+                    message,
+                    mmsi_info: None,
+                    nmea_sentences: vec![],
+                })
+                .await?;
         }
 
         Ok(())

--- a/crates/ship162/src/sources/tcp.rs
+++ b/crates/ship162/src/sources/tcp.rs
@@ -43,10 +43,10 @@ impl TcpSource {
         loop {
             match self.connect_and_process().await {
                 Ok(_) => {
-                    eprintln!("Connection closed, reconnecting...");
+                    tracing::warn!("Connection closed, reconnecting...");
                 }
                 Err(e) => {
-                    eprintln!("Error: {}, reconnecting in 5 seconds...", e);
+                    tracing::warn!("Error: {}, reconnecting in 5 seconds...", e);
                     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                 }
             }

--- a/crates/ship162/src/sources/websocket.rs
+++ b/crates/ship162/src/sources/websocket.rs
@@ -2,42 +2,32 @@ use anyhow::Result;
 use futures::StreamExt;
 use tokio::sync::mpsc::Sender;
 use tokio_tungstenite::connect_async;
-use tracing::{debug, info, warn};
+use tracing::debug;
 
 use rs162::decode::nmea::{MessageAssembler, NmeaAisMessage};
 use rs162::prelude::Message;
 
-use crate::sources::{TimedMessage, WsPath};
+use crate::{
+    sources::{TimedMessage, WsPath},
+    status::{ReconnectingSource, SourceRuntime, SourceStatus},
+};
 
 pub struct WsSource {
     tx: Sender<TimedMessage>,
+    runtime: SourceRuntime,
     path: WsPath,
 }
 
 impl WsSource {
-    pub fn new(tx: Sender<TimedMessage>, path: WsPath) -> Self {
-        Self { tx, path }
-    }
-
-    pub async fn run(&self) -> Result<()> {
-        loop {
-            match self.connect_and_process().await {
-                Ok(_) => {
-                    tracing::warn!("WebSocket connection closed, reconnecting...");
-                }
-                Err(e) => {
-                    tracing::warn!("WebSocket error: {}, reconnecting in 5 seconds...", e);
-                    tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                }
-            }
-        }
+    pub fn new(tx: Sender<TimedMessage>, runtime: SourceRuntime, path: WsPath) -> Self {
+        Self { tx, runtime, path }
     }
 
     async fn connect_and_process(&self) -> Result<()> {
         match &self.path {
             WsPath::Short(url) => {
                 let (ws_stream, _) = connect_async(url.as_str()).await?;
-                info!("Connected to WebSocket: {}", url);
+                self.runtime.report(SourceStatus::Connected);
                 let (_write, read) = ws_stream.split();
                 self.process_stream(read).await
             }
@@ -47,7 +37,7 @@ impl WsSource {
                     return self.connect_tunnelled(&ws.url, jump).await;
                 }
                 let (ws_stream, _) = connect_async(ws.url.as_str()).await?;
-                info!("Connected to WebSocket: {}", ws.url);
+                self.runtime.report(SourceStatus::Connected);
                 let (_write, read) = ws_stream.split();
                 self.process_stream(read).await
             }
@@ -76,8 +66,7 @@ impl WsSource {
             .connect()
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?;
-        info!("SSH tunnel established to {} via jump host {}", url, jump);
-
+        tracing::info!(url, jump, "ssh tunnel established");
         let request = Request::builder()
             .uri(url)
             .header("Host", parsed_url.host_str().unwrap_or("localhost"))
@@ -94,7 +83,7 @@ impl WsSource {
         let (ws_stream, _) = client_async(request, stream)
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?;
-        info!("Connected to WebSocket via tunnel: {}", url);
+        self.runtime.report(SourceStatus::Connected);
 
         let (_write, read) = ws_stream.split();
         self.process_stream(read).await
@@ -181,8 +170,17 @@ impl WsSource {
             }
         }
 
-        warn!("WebSocket stream ended");
         Ok(())
+    }
+}
+
+impl ReconnectingSource for WsSource {
+    fn runtime(&self) -> &SourceRuntime {
+        &self.runtime
+    }
+
+    async fn connect_once(&self) -> Result<()> {
+        self.connect_and_process().await
     }
 }
 

--- a/crates/ship162/src/sources/websocket.rs
+++ b/crates/ship162/src/sources/websocket.rs
@@ -23,10 +23,10 @@ impl WsSource {
         loop {
             match self.connect_and_process().await {
                 Ok(_) => {
-                    eprintln!("WebSocket connection closed, reconnecting...");
+                    tracing::warn!("WebSocket connection closed, reconnecting...");
                 }
                 Err(e) => {
-                    eprintln!("WebSocket error: {}, reconnecting in 5 seconds...", e);
+                    tracing::warn!("WebSocket error: {}, reconnecting in 5 seconds...", e);
                     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                 }
             }

--- a/crates/ship162/src/state.rs
+++ b/crates/ship162/src/state.rs
@@ -2,7 +2,9 @@ use rs162::{
     decode::mmsi::MmsiInfo,
     prelude::{NavigationStatus, ShipType},
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+
+use crate::status::{SourceEvent, SourceId};
 
 #[derive(Debug, Clone)]
 pub struct VesselState {
@@ -70,6 +72,7 @@ impl VesselState {
 pub struct AppState {
     vessels: HashMap<String, VesselState>,
     pub scroll_offset: usize,
+    source_statuses: BTreeMap<SourceId, SourceEvent>,
 }
 
 impl AppState {
@@ -95,6 +98,14 @@ impl AppState {
 
     pub fn vessel_count(&self) -> usize {
         self.vessels.len()
+    }
+
+    pub fn set_source_status(&mut self, status: SourceEvent) {
+        self.source_statuses.insert(status.source_id(), status);
+    }
+
+    pub fn source_statuses(&self) -> impl Iterator<Item = &SourceEvent> {
+        self.source_statuses.values()
     }
 
     pub fn scroll_up(&mut self) {

--- a/crates/ship162/src/status.rs
+++ b/crates/ship162/src/status.rs
@@ -1,0 +1,263 @@
+use std::{
+    borrow::Cow,
+    fmt,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::UnboundedSender;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(try_from = "f64", into = "f64")]
+pub struct RetryDelay(Duration);
+
+impl RetryDelay {
+    const DEFAULT: Self = Self(Duration::from_secs(5));
+
+    pub(crate) const fn duration(self) -> Duration {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for RetryDelay {
+    type Error = &'static str;
+
+    fn try_from(seconds: f64) -> Result<Self, Self::Error> {
+        if !seconds.is_finite() || seconds <= 0.0 {
+            return Err("retry delay must be finite and greater than zero");
+        }
+
+        let duration =
+            Duration::try_from_secs_f64(seconds).map_err(|_| "retry delay is out of range")?;
+        if duration.is_zero() {
+            return Err("retry delay is too small");
+        }
+
+        Ok(Self(duration))
+    }
+}
+
+impl From<RetryDelay> for f64 {
+    fn from(delay: RetryDelay) -> Self {
+        delay.duration().as_secs_f64()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "strategy", rename_all = "snake_case")]
+pub enum RetryPolicy {
+    Fixed {
+        #[serde(rename = "delay_seconds")]
+        delay: RetryDelay,
+    },
+    // TODO we might want to implement exponential backoff but keeping it simple for now
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self::Fixed {
+            delay: RetryDelay::DEFAULT,
+        }
+    }
+}
+
+impl RetryPolicy {
+    fn delay(self, _attempt: u32) -> Duration {
+        match self {
+            Self::Fixed { delay } => delay.duration(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourceId(usize);
+
+impl SourceId {
+    pub(crate) const fn from_index(index: usize) -> Self {
+        Self(index + 1)
+    }
+
+    const fn get(self) -> usize {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceStatus {
+    Connecting,
+    Connected,
+    Disconnected {
+        reason: Cow<'static, str>,
+        retry_in: Option<Duration>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceEvent {
+    source_id: SourceId,
+    source: Arc<str>,
+    status: SourceStatus,
+}
+
+impl SourceEvent {
+    pub(crate) const fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    pub(crate) fn log(&self) {
+        match &self.status {
+            SourceStatus::Connecting => {
+                tracing::info!(
+                    source_id = self.source_id.get(),
+                    source = self.source.as_ref(),
+                    status = "connecting",
+                    "source connecting"
+                );
+            }
+            SourceStatus::Connected => {
+                tracing::info!(
+                    source_id = self.source_id.get(),
+                    source = self.source.as_ref(),
+                    status = "connected",
+                    "source connected"
+                );
+            }
+            SourceStatus::Disconnected {
+                reason,
+                retry_in: Some(retry_in),
+            } => {
+                tracing::warn!(
+                    source_id = self.source_id.get(),
+                    source = self.source.as_ref(),
+                    status = "disconnected",
+                    reason = reason.as_ref(),
+                    retry_seconds = retry_in.as_secs_f64(),
+                    "source disconnected; retrying"
+                );
+            }
+            SourceStatus::Disconnected {
+                reason,
+                retry_in: None,
+            } => {
+                tracing::warn!(
+                    source_id = self.source_id.get(),
+                    source = self.source.as_ref(),
+                    status = "disconnected",
+                    reason = reason.as_ref(),
+                    "source disconnected"
+                );
+            }
+        }
+    }
+}
+
+impl fmt::Display for SourceEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.status {
+            SourceStatus::Connecting => write!(f, "{}: connecting", self.source),
+            SourceStatus::Connected => write!(f, "{}: connected", self.source),
+            SourceStatus::Disconnected {
+                reason,
+                retry_in: Some(retry_in),
+            } => write!(
+                f,
+                "{}: {reason}; retrying in {}s",
+                self.source,
+                retry_in.as_secs_f64()
+            ),
+            SourceStatus::Disconnected {
+                reason,
+                retry_in: None,
+            } => write!(f, "{}: {reason}; disconnected", self.source),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceReporter {
+    source_id: SourceId,
+    source: Arc<str>,
+    status_tx: UnboundedSender<SourceEvent>,
+}
+
+impl SourceReporter {
+    pub(crate) fn new(
+        source_id: SourceId,
+        source: impl Into<Arc<str>>,
+        status_tx: UnboundedSender<SourceEvent>,
+    ) -> Self {
+        Self {
+            source_id,
+            source: source.into(),
+            status_tx,
+        }
+    }
+
+    pub(crate) fn report(&self, status: SourceStatus) {
+        let _ = self.status_tx.send(SourceEvent {
+            source_id: self.source_id,
+            source: Arc::clone(&self.source),
+            status,
+        });
+    }
+}
+
+#[derive(Debug)]
+pub struct SourceRuntime {
+    reporter: SourceReporter,
+    retry_policy: RetryPolicy,
+    failed_attempts: AtomicU32,
+}
+
+impl SourceRuntime {
+    pub(crate) fn new(
+        source_id: SourceId,
+        source: impl Into<Arc<str>>,
+        status_tx: UnboundedSender<SourceEvent>,
+        retry_policy: RetryPolicy,
+    ) -> Self {
+        Self {
+            reporter: SourceReporter::new(source_id, source, status_tx),
+            retry_policy,
+            failed_attempts: AtomicU32::new(0),
+        }
+    }
+
+    pub(crate) fn report(&self, status: SourceStatus) {
+        if matches!(&status, SourceStatus::Connected) {
+            self.failed_attempts.store(0, Ordering::Relaxed);
+        }
+        self.reporter.report(status);
+    }
+
+    fn next_retry_in(&self) -> Duration {
+        let attempt = self.failed_attempts.fetch_add(1, Ordering::Relaxed);
+        self.retry_policy.delay(attempt)
+    }
+}
+
+pub(crate) trait ReconnectingSource {
+    fn runtime(&self) -> &SourceRuntime;
+
+    async fn connect_once(&self) -> anyhow::Result<()>;
+
+    async fn run(&self) {
+        loop {
+            self.runtime().report(SourceStatus::Connecting);
+            let reason = match self.connect_once().await {
+                Ok(()) => Cow::Borrowed("connection closed"),
+                Err(error) => Cow::Owned(error.to_string()),
+            };
+            let retry_in = self.runtime().next_retry_in();
+            self.runtime().report(SourceStatus::Disconnected {
+                reason,
+                retry_in: Some(retry_in),
+            });
+            tokio::time::sleep(retry_in).await;
+        }
+    }
+}

--- a/crates/ship162/src/table.rs
+++ b/crates/ship162/src/table.rs
@@ -18,7 +18,7 @@ pub fn render(frame: &mut Frame, state: &AppState) {
         .split(area);
 
     render_table(frame, chunks[0], state);
-    render_footer(frame, chunks[1]);
+    render_footer(frame, chunks[1], state);
 }
 
 fn render_table(frame: &mut Frame, area: Rect, state: &AppState) {
@@ -170,8 +170,29 @@ fn render_table(frame: &mut Frame, area: Rect, state: &AppState) {
     frame.render_widget(table, area);
 }
 
-fn render_footer(frame: &mut Frame, area: Rect) {
-    let text = " q: quit | j/k or ↓/↑: scroll | mouse wheel: scroll ";
+fn render_footer(frame: &mut Frame, area: Rect, state: &AppState) {
+    let controls = "q: quit | j/k or ↓/↑: scroll | mouse wheel: scroll";
+    let mut statuses = state
+        .source_statuses()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    // crude cutoff to make space for the controls
+    let status_width = usize::from(area.width).saturating_sub(controls.chars().count() + 5);
+    if statuses.chars().count() > status_width {
+        statuses = statuses
+            .chars()
+            .take(status_width.saturating_sub(1))
+            .collect();
+        if status_width > 0 {
+            statuses.push('…');
+        }
+    }
+    let text = if statuses.is_empty() {
+        format!(" {controls} ")
+    } else {
+        format!(" {statuses} | {controls} ")
+    };
     let colors = TableColors::new(&tailwind::CYAN);
     let paragraph = Paragraph::new(text)
         .style(Style::new().fg(colors.row_fg).bg(colors.buffer_bg))

--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,8 @@ gain = 49.6
 
 ### TCP
 
+TCP sources reconnect after a fixed five-second delay by default. Configure the delay per source with `retry`:
+
 ```toml
 [[sources]]
 tcp = "153.44.253.27:5631"
@@ -141,13 +143,19 @@ tcp = "153.44.253.27:5631"
 # With SSH tunnel (built-in, no openssh needed)
 [[sources]]
 tcp = { host = "remote-host", port = 5631, jump = "jumphost" }
+# optional
+retry = { strategy = "fixed", delay_seconds = 10 }
 ```
 
 ### WebSocket
 
+WebSocket sources also use the same fixed-delay retry policy by default:
+
 ```toml
 [[sources]]
 ws = "ws://remote-host:88888"
+# optional
+retry = { strategy = "fixed", delay_seconds = 10 }
 ```
 
 ### MQTT

--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,7 @@ mqtt = "mqtt://mqtt.digitraffic.fi"
 
 ## Output
 
-Decoded messages are emitted as JSON on stdout (`--verbose`), written to a file (`--output`), or published to Redis (`--redis-url`). The application can also re-broadcast decoded NMEA sentences to downstream consumers:
+Decoded messages are emitted as JSON on stdout (`--verbose`), written to a file (`--output`), or published to Redis (`--redis-url`). Verbose and interactive modes are mutually exclusive because each requires stdout; `--log-file -` is likewise unavailable with either mode. The application can also re-broadcast decoded NMEA sentences to downstream consumers:
 
 ```sh
 # Serve NMEA over TCP for other applications (e.g. OpenCPN)


### PR DESCRIPTION
Previously, background source and output tasks wrote diagnostics directly to stdout or stderr. This causes disconnect and reconnect messages (from tcp/websocket sources) to interfere with ratatui's alternate screen rendering:

<img width="1920" height="909" alt="Screenshot From 2026-07-23 23-06-38" src="https://github.com/user-attachments/assets/dbe14a8d-6a54-4640-aae8-e24bbc3716d0" />

To fix this I made a big refactor in `ship162`:

- replace runtime/background `e?println!` with tracing
- introduce typed lifecycle events (connecting, connected, disconnected), which are used to render the latest status for each source in the TUI footer, or sink it to the log file
- add a per-source `retry = { strategy = "fixed", delay_seconds = 5}` configuration for TCP and websockets sources (if we want to implement say an exponential backoff in the future we should be able to do so easily)
- instead of a generic `Source` struct which uses feature gates to toggle individual fields, use an enum of source-specific parsed config types
- reject `--verbose --interactive` because both require exclusive stdout
- reject `--log-file -` with either `--verbose` or `--interactive` to avoid mixing diagnostics with JSON output or terminal rendering

There are no changes to the core `rs162` and no breaking changes to the TOML shape.

The footer now looks like this:
<img width="1558" height="113" alt="image" src="https://github.com/user-attachments/assets/309c4be5-ab64-45e0-9cae-c91f4794ca0e" />
